### PR TITLE
Fix location and blocks creation of published files

### DIFF
--- a/configuration/Example.py
+++ b/configuration/Example.py
@@ -87,6 +87,6 @@ config.DBSPublisher.credentialDir = credentialDir
 config.DBSPublisher.serverDN = hostDN
 config.DBSPublisher.serviceCert = serviceCert
 config.DBSPublisher.serviceKey =  "/path/to/valid/host-key"
-config.DBSPublisher.min_files_per_block = 1
+config.DBSPublisher.max_files_per_block = 100
 config.DBSPublisher.workflow_expiration_time = 3
 


### PR DESCRIPTION
The location of published files are currently set to the storage of the site where the jobs have run. This patch get the targetSE from files documents in couch and set the location of published files to it. The block creation algorithm is also fixed to create block with a sufficient number of files.    
