### PR TITLE
Propagate transfers errors to the user_monitoring

### DIFF
--- a/src/couchapp/AsyncTransfer/views/LastUpdatePerFile/map.js
+++ b/src/couchapp/AsyncTransfer/views/LastUpdatePerFile/map.js
@@ -1,12 +1,12 @@
 function complete_job(doc, req) {
-        if ( doc['state'] != 'done' ) {
-                return false;
+        if ( doc['state'] != 'done' || doc['state'] != 'failed' ) {
+                return true;
         }
-        return true;
+        return false;
 }
 
 function(doc) {
 	if(doc.lfn && complete_job(doc)){
-		emit(doc.last_update, {"lfn": doc.lfn, "workflow": doc.workflow, "location": doc.destination, "checksum": doc.checksums, "jobid": doc.jobid, "retry_count": doc.retry_count.length+1, "size": doc.size});
+		emit(doc.last_update, {"lfn": doc.lfn, "state": doc.state, "errors": doc.failure_reason, "workflow": doc.workflow, "location": doc.destination, "checksum": doc.checksums, "jobid": doc.jobid, "retry_count": doc.retry_count.length+1, "size": doc.size});
 	}
 }

--- a/src/python/AsyncStageOut/AnalyticsDaemon.py
+++ b/src/python/AsyncStageOut/AnalyticsDaemon.py
@@ -163,17 +163,18 @@ class AnalyticsDaemon(BaseWorkerThread):
         all_files = self.db.loadView('AsyncTransfer', 'LastUpdatePerFile', query)['rows']
 
         for file in all_files:
-
             doc = {}
             doc['type'] = 'aso_file'
             doc['workflow'] = file['value']['workflow']
             doc['lfn'] = file['value']['lfn']
+            doc['state'] = file['value']['state']
+            if file['value'].has_key('errors'):
+                doc['errors'] = file['value']['errors']
             doc['location'] = file['value']['location']
             doc['checksum'] = file['value']['checksum']
             doc['jobid'] = file['value']['jobid']
             doc['retry_count'] = file['value']['retry_count']
             doc['size'] = file['value']['size']
-
             try:
                 self.monitoring_db.queue(doc, True)
             except Exception, ex:


### PR DESCRIPTION
As mentioned in #1113, the transfers errors need to be propagated to the end_user via the user_monitoring.  
