### PR TITLE
Fix mark_failed method in PublisherWorker Class

### DIFF
--- a/src/python/AsyncStageOut/PublisherWorker.py
+++ b/src/python/AsyncStageOut/PublisherWorker.py
@@ -215,7 +215,7 @@ class PublisherWorker:
         last_update = int(time.time())
         for lfn in files:
             data = {}
-            docId = getHashLfn(lfn.replace('store', 'store/temp', 1))
+            docId = getHashLfn(lfn)
             # Load document to get the retry_count
             try:
                 document = self.db.document( docId )


### PR DESCRIPTION
Fix the id of the document to load from couchdb in mark_failed method.
