### PR TITLE
Create aso_file document only for done files 

### DIFF
--- a/src/couchapp/AsyncTransfer/views/LastUpdatePerFile/map.js
+++ b/src/couchapp/AsyncTransfer/views/LastUpdatePerFile/map.js
@@ -1,5 +1,5 @@
 function complete_job(doc, req) {
-        if ( doc['state'] != 'done' || doc['state'] != 'failed' ) {
+        if ( doc['state'] == 'done' ) {
                 return true;
         }
         return false;
@@ -7,6 +7,6 @@ function complete_job(doc, req) {
 
 function(doc) {
 	if(doc.lfn && complete_job(doc)){
-		emit(doc.last_update, {"lfn": doc.lfn, "state": doc.state, "errors": doc.failure_reason, "workflow": doc.workflow, "location": doc.destination, "checksum": doc.checksums, "jobid": doc.jobid, "retry_count": doc.retry_count.length+1, "size": doc.size});
+		emit(doc.last_update, {"lfn": doc.lfn, "workflow": doc.workflow, "location": doc.destination, "checksum": doc.checksums, "jobid": doc.jobid, "retry_count": doc.retry_count.length+1, "size": doc.size});
 	}
 }

--- a/src/python/AsyncStageOut/AnalyticsDaemon.py
+++ b/src/python/AsyncStageOut/AnalyticsDaemon.py
@@ -182,9 +182,6 @@ class AnalyticsDaemon(BaseWorkerThread):
             doc['type'] = 'aso_file'
             doc['workflow'] = file['value']['workflow']
             doc['lfn'] = file['value']['lfn']
-            doc['state'] = file['value']['state']
-            if file['value'].has_key('errors'):
-                doc['errors'] = file['value']['errors']
             doc['location'] = file['value']['location']
             doc['checksum'] = file['value']['checksum']
             doc['jobid'] = file['value']['jobid']


### PR DESCRIPTION
Since the aso errors are got from the aso_workflow documents, the aso_file documents for failed files  are of no use and just increase the number of documents in the database. 
