### PR TITLE
Divide the transfer and publication status.

### DIFF
--- a/src/couchapp/UserMonitoring/views/PublicationStatesByWorkflow/map.js
+++ b/src/couchapp/UserMonitoring/views/PublicationStatesByWorkflow/map.js
@@ -1,0 +1,6 @@
+function(doc) {
+        if (doc.state) {
+                emit(doc._id, doc.publication_state);
+        }
+}
+

--- a/src/python/AsyncStageOut/AnalyticsDaemon.py
+++ b/src/python/AsyncStageOut/AnalyticsDaemon.py
@@ -59,7 +59,7 @@ class AnalyticsDaemon(BaseWorkerThread):
         c. clean user_monitoring_db database by removing old docs
         """
         self.updateWorkflowSummaries()
-        self.updateJobSummaries()
+#        self.updateJobSummaries()
         self.cleanOldDocs()
 
     def updateWorkflowSummaries(self):
@@ -69,28 +69,38 @@ class AnalyticsDaemon(BaseWorkerThread):
         """
         active_jobs = 0
         updated = 0
-        query = {'reduce':True, 'group': True}
-        active_jobs = self.db.loadView('AsyncTransfer', 'JobsSatesByWorkflow', query)['rows']
         states = {}
         now = int(time.time())
+
+        query = {'reduce':True, 'group': True}
+        active_jobs = self.db.loadView('AsyncTransfer', 'JobsSatesByWorkflow', query)['rows']
+
         for job in active_jobs:
+
             workflow = job['key']
             jobs_states = job['value']
+            all_states = {}
+            pub_state = {}
             query = {'reduce':True, 'group': True, 'key':workflow}
             publication_state = self.db.loadView('AsyncTransfer', 'PublicationStateByWorkflow', query)['rows']
             if publication_state:
-                jobs_states.update(publication_state[0]['value'])
-            current_states = clean_states( jobs_states )
+                all_states = publication_state[0]['value'].copy()
+            all_states.update(jobs_states)
+            current_states = clean_states( all_states )
             query = {'key': workflow}
             try:
-                states = self.monitoring_db.loadView('UserMonitoring', 'StatesByWorkflow', query)['rows'][0]['value']
+                mon_states = self.monitoring_db.loadView('UserMonitoring', 'StatesByWorkflow', query)['rows'][0]['value']
+                mon_publication_states = self.monitoring_db.loadView('UserMonitoring', 'PublicationStatesByWorkflow', query)['rows'][0]['value']
+                all_mon_states = dict(mon_states.items() + mon_publication_states.items())
             except IndexError:
                 # Prepare a new document and insert it in couch
-                states = current_states
                 doc = {}
+                doc['publication_state'] = {}
                 doc['_id'] = workflow
-                doc['state'] = current_states
-                if states.has_key("failed"):
+                doc['state'] = clean_states( jobs_states )
+                if publication_state:
+                    doc['publication_state'] = clean_states( publication_state[0]['value'].copy() )
+                if doc['state'].has_key("failed"):
                     failures_reasons = {}
                     query = {'reduce':True, 'group_level':2, 'startkey': [workflow], 'endkey':[workflow, {}]}
                     failures = self.db.loadView('AsyncTransfer', 'JobsByFailuresReasons', query)['rows']
@@ -110,11 +120,12 @@ class AnalyticsDaemon(BaseWorkerThread):
                     self.logger.error(msg)
                 continue
 
-            if states != current_states:
+            if all_mon_states != current_states:
                 try:
                     doc = self.monitoring_db.document( workflow )
-                    doc['state'] = current_states
-                    if current_states.has_key("failed"):
+                    doc['state'] = clean_states( jobs_states )
+	            doc['publication_state'] = clean_states( publication_state[0]['value'].copy() )
+                    if doc['state'].has_key("failed"):
                         failures_reasons = {}
                         query = {'reduce':True, 'group_level':2, 'startkey': [workflow], 'endkey':[workflow, {}]}
                         failures = self.db.loadView('AsyncTransfer', 'JobsByFailuresReasons', query)['rows']


### PR DESCRIPTION
Divide the transfer and publication status to provide a better snapshot of the file status.
