### PR TITLE
Remove redundant status info.

### DIFF
--- a/src/couchapp/AsyncTransfer/views/JobsSatesByWorkflow/reduce.js
+++ b/src/couchapp/AsyncTransfer/views/JobsSatesByWorkflow/reduce.js
@@ -1,8 +1,7 @@
 function (key, values, rereduce) {
-	var output = {'total': 0 ,'done': 0, 'failed': 0, 'acquired':0, 'new': 0};
+	var output = {'done': 0, 'failed': 0, 'acquired':0, 'new': 0};
 	if (rereduce) {
 		for (var someValue in values) {
-			output['total'] += values[someValue]['total'];
 			output['new'] += values[someValue]['new'];
 			output['done'] += values[someValue]['done'];
 			output['failed'] += values[someValue]['failed'];
@@ -12,7 +11,6 @@ function (key, values, rereduce) {
 	else {
 		for (var someValue in values) {
 			output[values[someValue]] += 1;
-			output['total'] += 1;
 		}
 	}
 	return output;


### PR DESCRIPTION
The total number of files can be deducted by summing the various states of files.
