### PR TITLE
Add file to allow operator manual kill of transfers

### DIFF
--- a/bin/kill-transfer
+++ b/bin/kill-transfer
@@ -1,0 +1,115 @@
+#!/usr/bin/env python
+
+"""
+Kill transfers by changing the state of documents in couchDB to 'killed'.
+For a given task, it can kill all its transfers or the transfers of specified documents.
+"""
+
+import os
+import sys, getopt
+
+from WMCore.Database.CMSCouch import CouchServer
+from WMCore.Configuration import loadConfigurationFile
+import urllib
+import datetime
+import time
+
+
+if __name__ == "__main__":
+
+    if not os.environ.has_key("WMAGENT_CONFIG"):
+        print "The WMAGENT_CONFIG environment variable needs to be set."
+        sys.exit(0)
+
+    def usage():
+        msg = """
+Usage:
+  kill-transfer -t <taskname> [-i docID comma separated list]
+Examples:
+  - To kill all transfers in a task:
+    kill-transfer -t <taskname>
+  - To kill the transfers for specific documents in a task:
+    kill-transfer -t <taskname> -i <docID1,docID2,...>
+"""
+        print(msg)
+
+    argv = sys.argv[1:]
+    if len(argv) == 0:
+        msg = "No arguments provided."
+        msg += " You need to provide (at least) the name of the task whose transfers you want to kill."
+        print msg
+        usage()
+        sys.exit(1)
+
+    valid_opts = ["-h","-t:","-i:"]
+    valid_long_opts = ["--help"]
+    try:
+        opts, args = getopt.getopt(argv,"".join([vo.strip("-") for vo in valid_opts]),[vo.strip("--") for vo in valid_long_opts])
+    except getopt.GetoptError, ex:
+        print str(ex)
+        usage()
+        sys.exit(2)
+
+    taskname = ''
+    docIDs = ''
+    valid_opts_no_colon = [vo.strip(":") for vo in valid_opts]
+    valid_long_opts_no_equal = [vo.strip("=") for vo in valid_long_opts]
+    for opt, arg in opts:
+        if opt in ("-h","--help"):
+            usage()
+            sys.exit(0)
+        if opt == "-t" and str(arg) not in valid_opts_no_colon + valid_long_opts_no_equal:
+            taskname = str(arg)
+        if opt == "-i" and str(arg) not in valid_opts_no_colon + valid_long_opts_no_equal:
+            docIDs = [id for id in str(arg).split(",") if id != '']
+    if taskname == '':
+        msg = "No task name provided."
+        print msg
+        usage()
+        sys.exit(3)
+    if len(docIDs):
+        print "Will kill transfers for task %s, documents %s." % (taskname,str(docIDs))
+    else:
+        print "Will kill all transfers for task %s." % taskname
+    
+    config = loadConfigurationFile(os.environ["WMAGENT_CONFIG"])
+    server = CouchServer(config.AsyncTransfer.couch_instance,config.AsyncTransfer.opsProxy,config.AsyncTransfer.opsProxy)
+    try:
+        database = server.connectDatabase(config.AsyncTransfer.files_database)
+    except Exception, ex:
+        msg = "Error while connecting to %s couchDB." % config.AsyncTransfer.files_database
+        print msg
+        sys.exit(4)
+    try:
+        docs_forKill = database.loadView('AsyncTransfer','forKill',{'reduce':False,'key':taskname})['rows']
+    except Exception, ex:
+        msg = "Error while connecting to %s couchDB" % config.AsyncTransfer.files_database
+        print msg
+        sys.exit(4)
+    if not len(docs_forKill):
+        msg = "Found no documents to kill."
+        print msg
+        sys.exit(0)
+    for doc in docs_forKill:
+        if doc['key'] != taskname:
+            continue
+        docid = doc['value']
+        if len(docIDs) and (docid not in docIDs):
+            continue
+        now = str(datetime.datetime.now())
+        data = {}
+        data['end_time'] = now
+        data['state'] = 'killed'
+        data['last_update'] = time.time()
+        data['retry'] = now
+        try:
+            database.updateDocument(docid,'AsyncTransfer','updateJobs',data)
+        except Exception, ex:
+            msg = "Error updating document %s in %s couchDB." % (docid,config.AsyncTransfer.files_database)
+            msg += str(ex)
+            msg += str(traceback.format_exc())
+            print msg
+            sys.exit(5)
+
+    sys.exit(0)
+


### PR DESCRIPTION
I reused code from Hassen from an old pull request (dmwm/CRABServer#4036). The code changes the state of documents in CouchDB to 'killed' using the updateDocument() method from class Database.
The script should be run using the manage script in dmwm/deployment/asyncstageout:
manage execute-asyncstageout kill-transfer -t taskname
This should solve issue  #4098.
