### PR TITLE
Adding function to translate SE names into CMS site names

### DIFF
--- a/src/python/AsyncStageOut/TransferDaemon.py
+++ b/src/python/AsyncStageOut/TransferDaemon.py
@@ -19,6 +19,7 @@ from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
 from AsyncStageOut.TransferWorker import TransferWorker
 from multiprocessing import Pool
 from WMCore.WMFactory import WMFactory
+from AsyncStageOut import getSiteNamesFromSENames
 #import random
 import logging
 #import time
@@ -138,8 +139,9 @@ class TransferDaemon(BaseWorkerThread):
 
         sites = self.active_sites()
         self.logger.info('%s active sites' % len(sites))
+        if len(sites):
+            sites = getSiteNamesFromSENames(sites, logging)
         self.logger.debug('Active sites are: %s' % sites)
-
         site_tfc_map = {}
         for site in sites:
             # TODO: Remove the Workaround for FNAL
@@ -163,6 +165,7 @@ class TransferDaemon(BaseWorkerThread):
                 site = 'T1_CH_CERN_Buffer'
             if site and str(site) != 'None':
                 site_tfc_map[site] = self.get_tfc_rules(site)
+
         self.logger.debug('kicking off pool')
         for u in users:
             self.logger.debug('current_running %s' %current_running)

--- a/src/python/AsyncStageOut/TransferWorker.py
+++ b/src/python/AsyncStageOut/TransferWorker.py
@@ -24,6 +24,7 @@ from WMCore.Credential.Proxy import Proxy
 from AsyncStageOut import getHashLfn
 from AsyncStageOut import getFTServer
 from AsyncStageOut import getDNFromUserName
+from AsyncStageOut import getSiteNamesFromSENames
 #import json
 #import socket
 #import stomp
@@ -376,6 +377,7 @@ class TransferWorker:
         except Exception, e:
             self.logger.error('it does not seem to be an lfn %s' %file.split(':'))
             return None
+        site = getSiteNamesFromSENames([site],self.logger)[0]
         if self.tfc_map.has_key(site):
             pfn = self.tfc_map[site].matchLFN('srmv2', lfn)
             #TODO: improve fix for wrong tfc on sites

--- a/src/python/AsyncStageOut/__init__.py
+++ b/src/python/AsyncStageOut/__init__.py
@@ -1,7 +1,9 @@
 import hashlib
 import subprocess
 import os
+import datetime
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
 
 __version__ = '1.0.1'
 
@@ -56,4 +58,58 @@ def getDNFromUserName(username, log):
        log.error("SiteDB URL cannot be accessed")
        return dn
     return dn
+
+se_site_map = {}
+se_site_map_last_update = None
+
+def getSiteNamesFromSENames(sites, log, force=False):
+    """
+    When injecting from the WN, the CMS site name for the temporary stageout location is not known.
+    Only the SE name is know.
+    """
+
+    def make_se_site_map():
+        log.debug("Will generate SE-Site map")
+        try:
+            phedex = PhEDEx()
+        except Exception, e:
+            log.debug("Could not initialize PhEDEx!:" %e)
+            return False
+        global se_site_map
+        se_site_map = {}
+        nodes = phedex.getNodeMap()['phedex']['node']
+        for node in nodes:
+            se_site_map[str(node[u'se'])] = str(node[u'name'])
+        if not se_site_map:
+            return False
+        global se_site_map_last_update
+        se_site_map_last_update = datetime.datetime.now()
+        return True
+
+    make_map = force
+    if not force:
+        if not se_site_map:
+            make_map = True
+        else:
+            # In any case, update the se_site_map every 1 day.
+            interval_for_update = datetime.timedelta(days=1)
+            now = datetime.datetime.now()
+            if (type(se_site_map_last_update) != type(now)) or \
+               ((now - se_site_map_last_update) >= interval_for_update):
+                make_map = True
+    if make_map and not make_se_site_map():
+        log.debug("Could not generate SE-Site map!:")
+    if not se_site_map:
+        return []
+    all_site_names = se_site_map.values()
+
+    def keys_map(site):
+        if (site in all_site_names) or (site[:3] in ['T1_','T2_','T3_']):
+            return site
+        if not se_site_map.has_key(site):
+            log.debug("Name %s not found in the PhEDEx node map" % site)
+            return ''
+        return se_site_map[site]
+
+    return map(keys_map,sites)
 


### PR DESCRIPTION
Added a function in AsyncStageOut __init__.py that takes as input a list of site names (the list can contain a mix of SE names and CMS site names) and returns another list of the same length and order preserved where the SE names were replaced by their corresponding CMS site names.  
The translation is done using PhEDEx: the function creates a map (called se_site_map) with SEnames as keys and CMS site names as values and uses the map for the translation.
The function is used in two places: 
1) in the TransferDaemon after getting the list of active sites, before creating the tfc_map (=> this means the tfc_map keeps CMS site names as keys);
2) in the TransferWorker before using the tfc_map (the tfc_map has CMS site names as keys while the site name in the worker is read from couch).

The connection to PhEDEx is done when creating/updating the se_site_map, and this is done: 
A) in the TransferDaemon (once every 30 minutes);
B) in each TransferWorker instance (i.e. per user, per retry). 
Notice, the TransferWorker creates its own se_site_map, it doesn't use the one created by the TransferDaemon. Maybe we can avoid this and use the map from the daemon? I didn't know how to do this, unless I pass the map as a new argument to the ftscp function so that it passes it then to the TransferWorker.