### PR TITLE
Monitoring using new views

### DIFF
--- a/src/couchapp/monitor/_attachments/dest-source-stat.html
+++ b/src/couchapp/monitor/_attachments/dest-source-stat.html
@@ -1,382 +1,567 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>AsyncTransfer Monitor System</title>
-    <link rel="stylesheet" href="style/main.css" type="text/css">
-    <script language="JavaScript" src="calendar_db.js"></script>
-	<link rel="stylesheet" href="calendar.css">
-
-  </head>
-  <body>
-  <div id="main">
-    <div id="head"><h2>AsyncTransfer Monitor System</h2></div>
-
-
-    <div id="sidebar"><p></p></div>
-
-    <div id="items">
-    <form name="selectionform">
-
+    <head>
+        <title>AsyncTransfer Monitor System</title>
+        <link rel="stylesheet" href="style/main.css" type="text/css">
+        <script language="JavaScript" src="calendar_db.js"></script>
+        <link rel="stylesheet" href="calendar.css">
+    </head>
+    <body>
+    <div id="main">
+        <div id="head"><h2>AsyncTransfer Monitor System</h2></div>
+        <div id="sidebar"><p></p></div>
+        <div id="items">
+        <form name="datetimeform" id="datetimeform">
 	<!-- calendar attaches to existing form element -->
-	<a>Start Date&nbsp;</a>
-	<input type="text" id="start" />
+        <a>&nbsp;&nbsp;Start Date&nbsp;</a>
+        <input type="text" id="start" value="" />
 	<script language="JavaScript">
 	var o_cal = new tcal ({
 		// form name
 		//'formname': 'testform',
 		// input name
 		'controlname': 'start'
-	});
-
-	// individual template parameters can be modified via the calendar variable
-	o_cal.a_tpl.yearscroll = false;
-	o_cal.a_tpl.weekstart = 1;
-
-	</script>
-	<a>Start Time</a>
-	<select id="starttime">
-  		<option value="0">00:00</option>
-  		<option value="1">01:00</option>
-  		<option value="2">02:00</option>
-  		<option value="3">03:00</option>
-  		<option value="4">04:00</option>
-		<option value="5">05:00</option>
-  		<option value="6">06:00</option>
-  		<option value="7">07:00</option>
-  		<option value="8">08:00</option>
-  		<option value="9">09:00</option>
-  		<option value="10">10:00</option>
-  		<option value="11">11:00</option>
-  		<option value="12">12:00</option>
-		<option value="13">13:00</option>
-  		<option value="14">14:00</option>
-  		<option value="15">15:00</option>
-  		<option value="16">16:00</option>
-  		<option value="17">17:00</option>
-  		<option value="18">18:00</option>
-  		<option value="19">19:00</option>
-  		<option value="20">20:00</option>
-		<option value="21">21:00</option>
-  		<option value="22">22:00</option>
-  		<option value="23">23:00</option>
-	</select>
-
-	<a>&nbsp;&nbsp;End Date&nbsp;</a>
-	<input type="text" name="testinput2" id="end" />
-	<script language="JavaScript">
-	var A_CALTPL = {
-		'months' : ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
-		'weekdays' : ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
-		'yearscroll': true,
-		'weekstart': 0,
-		'centyear'  : 70,
-		'imgpath' : 'img/'
-	}
-
-	new tcal ({
-		// if referenced by ID then form name is not required
-		'controlname': 'end'
-	}, A_CALTPL);
-	</script>
-	<a>End Time</a>
-	<select id="endtime">
-  		<option value="0">00:00</option>
-  		<option value="1">01:00</option>
-  		<option value="2">02:00</option>
-  		<option value="3">03:00</option>
-  		<option value="4">04:00</option>
-		<option value="5">05:00</option>
-  		<option value="6">06:00</option>
-  		<option value="7">07:00</option>
-  		<option value="8">08:00</option>
-  		<option value="9">09:00</option>
-  		<option value="10">10:00</option>
-  		<option value="11">11:00</option>
-  		<option value="12">12:00</option>
-		<option value="13">13:00</option>
-  		<option value="14">14:00</option>
-  		<option value="15">15:00</option>
-  		<option value="16">16:00</option>
-  		<option value="17">17:00</option>
-  		<option value="18">18:00</option>
-  		<option value="19">19:00</option>
-  		<option value="20">20:00</option>
-		<option value="21">21:00</option>
-  		<option value="22">22:00</option>
-  		<option value="23">23:00</option>
-	</select>
-
-	<INPUT TYPE="button" NAME="button" Value="View" onClick='setTime($("input#start").val(),$("input#end").val())'>
-	<INPUT TYPE="button" NAME="buttonreset" Value="Default" onClick='resetTime()'>
-
-
-	</form>
-	<h2 id= "dest">Destination Site Monitoring</h2>
-	<h3>Status of Active Files</h3>
-	<div id="startedd"> Retriving Data... </div>
-	<h3>Status of Ended Files</h3>
-	<div id="endedd"> Retriving Data... </div>
-	<br>
-	<h2 id= "source">Source Site Monitoring</h2>
-	<h3>Status of Active Files</h3>
-	<div id="starteds"> Retriving Data... </div>
-	<h3>Status of Ended Files</h3>
-	<div id="endeds"> Retriving Data... </div>
-
+        });
+        // individual template parameters can be modified via the calendar variable
+        o_cal.a_tpl.yearscroll = true;
+        o_cal.a_tpl.weekstart = 1;
+        </script>
+        <a>&nbsp;&nbsp;Start Time&nbsp;</a>
+        <select id="starttime">
+                <option value="-1"></option>
+                <option value="0">00:00</option>
+                <option value="1">01:00</option>
+                <option value="2">02:00</option>
+                <option value="3">03:00</option>
+                <option value="4">04:00</option>
+                <option value="5">05:00</option>
+                <option value="6">06:00</option>
+                <option value="7">07:00</option>
+                <option value="8">08:00</option>
+                <option value="9">09:00</option>
+                <option value="10">10:00</option>
+                <option value="11">11:00</option>
+                <option value="12">12:00</option>
+                <option value="13">13:00</option>
+                <option value="14">14:00</option>
+                <option value="15">15:00</option>
+                <option value="16">16:00</option>
+                <option value="17">17:00</option>
+                <option value="18">18:00</option>
+                <option value="19">19:00</option>
+                <option value="20">20:00</option>
+                <option value="21">21:00</option>
+                <option value="22">22:00</option>
+                <option value="23">23:00</option>
+        </select>
+        <a>&nbsp;&nbsp;&nbsp;&nbsp;End Date&nbsp;</a>
+        <input type="text" name="testinput2" id="end" value="" />
+        <script language="JavaScript">
+        //var A_CALTPL = {
+        //      'months' : ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        //      'weekdays' : ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
+        //      'yearscroll': true,
+        //      'weekstart': 0,
+        //      'centyear'  : 70,
+        //      'imgpath' : 'img/'
+        //}
+        var e_cal = new tcal ({
+                // if referenced by ID then form name is not required
+                'controlname': 'end'
+        }); //, A_CALTPL);
+        e_cal.a_tpl.yearscroll = true;
+        e_cal.a_tpl.weekstart = 1;
+        </script>
+        <a>&nbsp;&nbsp;End Time&nbsp;</a>
+        <select id="endtime">
+                <option value="-1"></option>
+                <option value="0">00:00</option>
+                <option value="1">01:00</option>
+                <option value="2">02:00</option>
+                <option value="3">03:00</option>
+                <option value="4">04:00</option>
+                <option value="5">05:00</option>
+                <option value="6">06:00</option>
+                <option value="7">07:00</option>
+                <option value="8">08:00</option>
+                <option value="9">09:00</option>
+                <option value="10">10:00</option>
+                <option value="11">11:00</option>
+                <option value="12">12:00</option>
+                <option value="13">13:00</option>
+                <option value="14">14:00</option>
+                <option value="15">15:00</option>
+                <option value="16">16:00</option>
+                <option value="17">17:00</option>
+                <option value="18">18:00</option>
+                <option value="19">19:00</option>
+                <option value="20">20:00</option>
+                <option value="21">21:00</option>
+                <option value="22">22:00</option>
+                <option value="23">23:00</option>
+        </select>
+        &nbsp;&nbsp;&nbsp;&nbsp;<INPUT TYPE="button" NAME="buttonreset" Value="Default" onClick='resetDateTime();setOptions();drawchart()'>
+        </form>
+        <form name="yaxisform" id="yaxisform">
+        <a>&nbsp;&nbsp;Y-Axis Unit&nbsp;</a>
+        <select id="yaxis">
+                <option value="njobs" text="Number of Files">Number of Files</option>
+                <option value="size" text="Files Size (MB)">Files Size (MB)</option>
+        </select>
+        </form>
+        <center><INPUT TYPE="button" NAME="button" Value="Reload Plots" onClick='setOptions();drawchart()'></center>
+        <h2 id= "dest">Destination Site Monitoring</h2>
+        <h3>Status of Active Files</h3>
+        <div id="startedd"> Retriving Data... </div>
+        <h3>Status of Ended Files</h3>
+        <div id="endedd"> Retriving Data... </div>
+        <h3>Status of Killed and Resubmitted Files</h3>
+        <div id="endedds"> Retriving Data... </div>
+        <br>
+        <h2 id= "source">Source Site Monitoring</h2>
+        <h3>Status of Active Files</h3>
+        <div id="starteds"> Retriving Data... </div>
+        <h3>Status of Ended Files</h3>
+        <div id="endeds"> Retriving Data... </div>
+        <h3>Status of Killed and Resubmitted Files</h3>
+        <div id="endedss"> Retriving Data... </div>
+        </div>
     </div>
-  </div>
-  </body>
-
+    </body>
 
 <script src="vendor/couchapp/loader.js"></script>
-
 <script type="text/javascript" charset="utf-8">
-  $.couch.app(function(app) {
+
+$.couch.app(function(app) {
     //$("#items").evently("destsourcetime", app);
     $("#sidebar").evently("menu", app)
     $("#head").evently("head", app)
-
-  });
-
-  $(document).ready(function() {
-          // put all your jQuery goodness in here.
-	$("h2#dest").html("Destination Site Monitoring ["+dest+"]");
-	$("h2#source").html("Source Site Monitoring ["+src+"]");
-	drawchart();
-	setInterval(function() drawchart(), 60000);
 });
 
-function parseGetVars()
-{
-  var args = new Array();
-  var query = window.location.search.substring(1);
-  if (query)
-  {
-    var strList = query.split('&');
-    for(str in strList)
-    {
-      var parts = strList[str].split('=');
-      args[unescape(parts[0])] = unescape(parts[1]);
+$(document).ready(function() {
+    // put all your jQuery goodness in here.
+    $("h2#dest").html("Destination Site Monitoring ["+dest+"]");
+    $("h2#source").html("Source Site Monitoring ["+src+"]");
+    drawchart();
+    setInterval(function() drawchart(), 60000);
+});
+
+function parseGetVars() {
+    var args = new Array();
+    var query = window.location.search.substring(1);
+    if (query) {
+        var strList = query.split('&');
+        for (str in strList) {
+            var parts = strList[str].split('=');
+            args[unescape(parts[0])] = unescape(parts[1]);
+        }
     }
-  }
-  return args;
+    return args;
 }
 
 var get = parseGetVars();
 var dest = get['index'].split(',')[0];
 var src = get['index'].split(',')[1];
+
 var timeSlice = 3600000;
-var startd = new Date();
-var endd = new Date();
-var defaultTime = true;
-
-inputes = [];
-inputes.stacked = [];
-inputes.status = ["done","failed"];
-
-inputss = [];
-inputss.stacked = [];
-inputss.status = ["new","acquired"];
-
-inputed = [];
-inputed.stacked = [];
-inputed.status = ["done","failed"];
 
 inputsd = [];
 inputsd.stacked = [];
 inputsd.status = ["new","acquired"];
 
+inputed = [];
+inputed.stacked = [];
+inputed.status = ["done","failed"];
 
-function setTime(start, end){
-			var startdate = new Date(start);
-			startdate.setUTCHours($("#starttime").val());
-			var enddate = new Date(end);
-			enddate.setUTCHours($("#endtime").val());
-			if(enddate<startdate){
-				alert("Error: start time bigger than end time");
-			}else{
-				startd = startdate;
-				endd = enddate;
+inputeds = [];
+inputeds.stacked = [];
+inputeds.status = ["resubmitted","killed"];
 
-				}
-				defaultTime = false;
-				drawchart();
-			}
+inputss = [];
+inputss.stacked = [];
+inputss.status = ["new","acquired"];
 
-function resetTime(){
-	defaultTime = true;
-	drawchart();
+inputes = [];
+inputes.stacked = [];
+inputes.status = ["done","failed"];
 
-	}
+inputess = [];
+inputess.stacked = [];
+inputess.status = ["resubmitted","killed"];
 
-function calcInterval(){
-	var now = new Date();
+var startd = new Date();
+var endd = new Date();
+var defaultDateTime = true;
+
+var yaxis = ("njobs").toString();
+var MB = 1048576;
+
+function isStartDateDefined() {
+    return ($("input#start").val() != '');
+}
+
+function isEndDateDefined() {
+    return ($("input#end").val() != '');
+}
+
+function isStartTimeDefined() {
+    return ($("#starttime").val() > -1);
+}
+
+function isEndTimeDefined() {
+    return ($("#endtime").val() > -1);
+}
+
+function isStartDateTimeDefined() {
+    return (isStartDateDefined() && isStartTimeDefined());
+}
+
+function isEndDateTimeDefined() {
+    return (isEndDateDefined() && isEndTimeDefined());
+}
+
+function getStartDate() {
+    if (isStartDateDefined()) {
+        return $("input#start").val();
+    }
+    var now = new Date();
+    return now.getDate()-1;
+}
+
+function getEndDate() {
+    if (isEndDateDefined()) {
+        return $("input#end").val();
+    }
+    var now = new Date();
+    return now.getDate();
+}
+
+function getStartTime() {
+    if (isStartTimeDefined()) {
+        return $("#starttime").val();
+    }
+    return 0;
+}
+
+function getEndTime() {
+    if (isEndTimeDefined()) {
+        return $("#endtime").val();
+    }
+    return 0;
+}
+
+function setDateTime() {
+    if (isStartDateTimeDefined() && isEndDateTimeDefined()) {
+        var startdate = new Date(getStartDate());
+        startdate.setUTCHours(getStartTime());
+        var enddate = new Date(getEndDate());
+        enddate.setUTCHours(getEndTime());
+        if (enddate < startdate) {
+            alert("Error: start date/time bigger than end date/time");
+        }
+        else {
+            startd = startdate;
+            endd = enddate;
+        }
+        defaultDateTime = false;
+    }
+    else {
+        resetDateTime();
+    }
+}
+
+function resetDateTime() {
+    defaultDateTime = true;
+    document.getElementById('datetimeform').reset();
+}
+
+function getYAxis() {
+    return ($("#yaxis").val()).toString();
+}
+
+function getYAxisLabel() {
+    if (getYAxis() == "njobs") {
+        return "Number of Files";
+    }
+    else if (getYAxis() == "size") {
+        return "Files Size (MB)";
+    }
+    return "";
+}
+
+function setYAxis() {
+    yaxis = getYAxis();
+}
+
+function setOptions() {
+    setDateTime();
+    setYAxis();
+}
+
+function calcInterval() {
+    var now = new Date();
     var start = new Date(now);
     start.setDate(start.getDate()-1);
-	startd = start;
-	endd = now;
-
-	}
-
-
-inputes.popolate = function(){
-		inputes.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-		var startkey =  ['"'+src+'"', startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = ['"'+src+'"', endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/endedByTimeSource?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var donefile = [];
-			var failfile = [];
-			for(i=0; i<=hours; i++){
-
-			var key = [src, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var doneF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var failF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-				doneF.value= response[rs].value.done;
-				failF.value= response[rs].value.failed;
-				rs = rs+1;
-			}
-			donefile.push(doneF);
-			failfile.push(failF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inputes.stacked.push(donefile);
-		inputes.stacked.push(failfile);
+    startd = start;
+    endd = now;
 }
 
-inputss.popolate = function(){
-		inputss.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-			var startkey =  ['"'+src+'"', startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = ['"'+src+'"', endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/startedByTimeSource?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var newfile = [];
-			var acqfile = [];
-			for(i=0; i<=hours; i++){
-
-			var key = [src, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var newF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var acqF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-				newF.value= response[rs].value.new;
-				acqF.value= response[rs].value.acquired;
-				rs = rs+1;
-			}
-			newfile.push(newF);
-			acqfile.push(acqF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inputss.stacked.push(newfile);
-		inputss.stacked.push(acqfile);
+function getDateTimeKey(DateObj,format,site) {
+    if (format != "axisTickLabel" && format != "view") format = "view";
+    if (format == "axisTickLabel") {
+        return DateObj.getUTCMonth()+1+"/"+DateObj.getUTCDate()+" "+DateObj.getUTCHours()+":00";
+    }
+    else if (format == "view") {
+        return ['"'+site+'"', DateObj.getUTCFullYear(), DateObj.getUTCMonth()+1, DateObj.getUTCDate(), DateObj.getUTCHours()];
+    }
 }
 
-inputed.popolate = function(){
-		inputed.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-		var startkey =  ['"'+dest+'"', startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = ['"'+dest+'"', endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/endedByTimeDest?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var donefile = [];
-			var failfile = [];
-			for(i=0; i<=hours; i++){
-
-			var key = [dest, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var doneF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var failF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-				doneF.value= response[rs].value.done;
-				failF.value= response[rs].value.failed;
-				rs = rs+1;
-			}
-			donefile.push(doneF);
-			failfile.push(failF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inputed.stacked.push(donefile);
-		inputed.stacked.push(failfile);
+inputsd.popolate = function() {
+    inputsd.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view",dest); //['"'+dest+'"', startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
+    var endkey = getDateTimeKey(endd,"view",dest); //['"'+dest+'"', endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/startedSizeByTimeDest?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var newfile = [];
+    var acqfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = [dest, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
+        //alert(key.toString());
+        var newF = {"time": getDateTimeKey(tslice,"axisTickLabel",dest),"value": 0};
+        var acqF = {"time": getDateTimeKey(tslice,"axisTickLabel",dest),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                newF.value = response[rs].value.new.njobs;
+                acqF.value= response[rs].value.acquired.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                newF.value = response[rs].value.new.size/MB;
+                acqF.value= response[rs].value.acquired.size/MB;
+            }
+            rs = rs+1;
+        }
+        newfile.push(newF);
+        acqfile.push(acqF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputsd.stacked.push(newfile);
+    inputsd.stacked.push(acqfile);
 }
 
-inputsd.popolate = function(){
-		inputsd.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-			var startkey =  ['"'+dest+'"', startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = ['"'+dest+'"', endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/startedByTimeDest?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var newfile = [];
-			var acqfile = [];
-			for(i=0; i<=hours; i++){
-
-			var key = [dest, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var newF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var acqF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-
-				newF.value= response[rs].value.new;
-				acqF.value= response[rs].value.acquired;
-				rs = rs+1;
-			}
-			newfile.push(newF);
-			acqfile.push(acqF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inputsd.stacked.push(newfile);
-		inputsd.stacked.push(acqfile);
+inputed.popolate = function() {
+    inputed.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view",dest);
+    var endkey = getDateTimeKey(endd,"view",dest);
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/endedSizeByTimeDest?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var donefile = [];
+    var failfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = [dest, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
+        //alert(key.toString());
+        var doneF = {"time": getDateTimeKey(tslice,"axisTickLabel",dest),"value": 0};
+        var failF = {"time": getDateTimeKey(tslice,"axisTickLabel",dest),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                doneF.value = response[rs].value.done.njobs;
+                failF.value = response[rs].value.failed.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                doneF.value = response[rs].value.done.size/MB;
+                failF.value = response[rs].value.failed.size/MB;
+            }
+            rs = rs+1;
+        }
+        donefile.push(doneF);
+        failfile.push(failF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputed.stacked.push(donefile);
+    inputed.stacked.push(failfile);
 }
 
-function drawchart(){
-	if(defaultTime){
-		calcInterval();
-	}
-	inputsd.popolate();
-	setTimeout(function() stackedArea("startedd", inputsd) , 1000 );
-	inputed.popolate();
-	setTimeout(function() stackedArea("endedd", inputed) , 1000 );
-	inputss.popolate();
-	setTimeout(function() stackedArea("starteds", inputss) , 1000 );
-	inputes.popolate();
-	setTimeout(function() stackedArea("endeds", inputes) , 1000 );
+inputeds.popolate = function() {
+    inputeds.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view",dest);
+    var endkey = getDateTimeKey(endd,"view",dest);
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/endedSizeByTimeDest?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var killfile = [];
+    var empfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = [dest, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
+        //alert(key.toString());
+        var killF = {"time": getDateTimeKey(tslice,"axisTickLabel",dest),"value": 0};
+        var empF = {"time": getDateTimeKey(tslice,"axisTickLabel",dest),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                killF.value = response[rs].value.killed.njobs;
+                empF.value = response[rs].value.resubmitted.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                killF.value = response[rs].value.killed.size/MB;
+                empF.value = response[rs].value.resubmitted.size/MB;
+            }
+            rs = rs+1;
+        }
+        killfile.push(killF);
+        empfile.push(empF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputeds.stacked.push(empfile);
+    inputeds.stacked.push(killfile);
 }
+
+inputss.popolate = function() {
+    inputss.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view",src);
+    var endkey = getDateTimeKey(endd,"view",src);
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/startedSizeByTimeSource?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var newfile = [];
+    var acqfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = [src, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
+        //alert(key.toString());
+        var newF = {"time": getDateTimeKey(tslice,"axisTickLabel",src),"value": 0};
+        var acqF = {"time": getDateTimeKey(tslice,"axisTickLabel",src),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                newF.value = response[rs].value.new.njobs;
+                acqF.value = response[rs].value.acquired.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                newF.value = response[rs].value.new.size/MB;
+                acqF.value = response[rs].value.acquired.size/MB;
+            }
+            rs = rs+1;
+        }
+        newfile.push(newF);
+        acqfile.push(acqF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputss.stacked.push(newfile);
+    inputss.stacked.push(acqfile);
+}
+
+inputes.popolate = function() {
+    inputes.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view",src);
+    var endkey = getDateTimeKey(endd,"view",src);
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/endedSizeByTimeSource?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var donefile = [];
+    var failfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = [src, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
+        //alert(key.toString());
+        var doneF = {"time": getDateTimeKey(tslice,"axisTickLabel",src),"value": 0};
+        var failF = {"time": getDateTimeKey(tslice,"axisTickLabel",src),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                doneF.value = response[rs].value.done.njobs;
+                failF.value = response[rs].value.failed.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                doneF.value = response[rs].value.done.size/MB;
+                failF.value = response[rs].value.failed.size/MB;
+            }
+            rs = rs+1;
+        }
+        donefile.push(doneF);
+        failfile.push(failF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputes.stacked.push(donefile);
+    inputes.stacked.push(failfile);
+}
+
+inputess.popolate = function() {
+    inputess.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view",src);
+    var endkey = getDateTimeKey(endd,"view",src);
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/endedSizeByTimeSource?stale=ok&group_level=5&startkey=[" + startkey + "]&endkey=[" + endkey +"]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var killfile = [];
+    var empfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = [src, tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
+        //alert(key.toString());
+        var killF = {"time": getDateTimeKey(tslice,"axisTickLabel",src),"value": 0};
+        var empF  = {"time": getDateTimeKey(tslice,"axisTickLabel",src),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                killF.value = response[rs].value.killed.njobs;
+                empF.value  = response[rs].value.resubmitted.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                killF.value = response[rs].value.killed.size/MB;
+                empF.value  = response[rs].value.resubmitted.size/MB;
+            }
+            rs = rs+1;
+        }
+        killfile.push(killF);
+        empfile.push(empF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputess.stacked.push(empfile);
+    inputess.stacked.push(killfile);
+}
+
+function drawchart() {
+    if (defaultDateTime) {
+        calcInterval();
+    }
+    inputsd.popolate();
+    inputed.popolate();
+    inputeds.popolate();
+    inputss.popolate();
+    inputes.popolate();
+    inputess.popolate();
+    setTimeout(function() stackedArea("startedd",inputsd,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("endedd",inputed,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("endedds",inputeds,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("starteds",inputss,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("endeds",inputes,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("endedss",inputess,getYAxisLabel()),1000);
+}
+
 </script>
-
 
 </html>

--- a/src/couchapp/monitor/_attachments/index.html
+++ b/src/couchapp/monitor/_attachments/index.html
@@ -1,150 +1,141 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>AsyncTransfer Monitor System</title>
-    <link rel="stylesheet" href="style/main.css" type="text/css">
-    <script language="JavaScript" src="calendar_db.js"></script>
-	<link rel="stylesheet" href="calendar.css">
-
-  </head>
-  <body>
-  <div id="main">
-    <div id="head"><h2>AsyncTransfer Monitor System</h2></div>
-
-
-    <div id="sidebar"><p></p></div>
-
-	<div id="items">
-
-	    <form name="selectionform">
-
-	<!-- calendar attaches to existing form element -->
-	<a>Start Date&nbsp;</a>
-	<input type="text" id="start" />
-	<script language="JavaScript">
-	var o_cal = new tcal ({
-		// form name
-		//'formname': 'testform',
-		// input name
-		'controlname': 'start'
-	});
-
-	// individual template parameters can be modified via the calendar variable
-	o_cal.a_tpl.yearscroll = false;
-	o_cal.a_tpl.weekstart = 1;
-
-	</script>
-	<a>Start Time</a>
-	<select id="starttime">
-  		<option value="0">00:00</option>
-  		<option value="1">01:00</option>
-  		<option value="2">02:00</option>
-  		<option value="3">03:00</option>
-  		<option value="4">04:00</option>
-		<option value="5">05:00</option>
-  		<option value="6">06:00</option>
-  		<option value="7">07:00</option>
-  		<option value="8">08:00</option>
-  		<option value="9">09:00</option>
-  		<option value="10">10:00</option>
-  		<option value="11">11:00</option>
-  		<option value="12">12:00</option>
-		<option value="13">13:00</option>
-  		<option value="14">14:00</option>
-  		<option value="15">15:00</option>
-  		<option value="16">16:00</option>
-  		<option value="17">17:00</option>
-  		<option value="18">18:00</option>
-  		<option value="19">19:00</option>
-  		<option value="20">20:00</option>
-		<option value="21">21:00</option>
-  		<option value="22">22:00</option>
-  		<option value="23">23:00</option>
-	</select>
-
-	<a>&nbsp;&nbsp;End Date&nbsp;</a>
-	<input type="text" name="testinput2" id="end" />
-	<script language="JavaScript">
-	var A_CALTPL = {
-		'months' : ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
-		'weekdays' : ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
-		'yearscroll': true,
-		'weekstart': 0,
-		'centyear'  : 70,
-		'imgpath' : 'img/'
-	}
-
-	new tcal ({
-		// if referenced by ID then form name is not required
-		'controlname': 'end'
-	}, A_CALTPL);
-	</script>
-	<a>End Time</a>
-	<select id="endtime">
-  		<option value="0">00:00</option>
-  		<option value="1">01:00</option>
-  		<option value="2">02:00</option>
-  		<option value="3">03:00</option>
-  		<option value="4">04:00</option>
-		<option value="5">05:00</option>
-  		<option value="6">06:00</option>
-  		<option value="7">07:00</option>
-  		<option value="8">08:00</option>
-  		<option value="9">09:00</option>
-  		<option value="10">10:00</option>
-  		<option value="11">11:00</option>
-  		<option value="12">12:00</option>
-		<option value="13">13:00</option>
-  		<option value="14">14:00</option>
-  		<option value="15">15:00</option>
-  		<option value="16">16:00</option>
-  		<option value="17">17:00</option>
-  		<option value="18">18:00</option>
-  		<option value="19">19:00</option>
-  		<option value="20">20:00</option>
-		<option value="21">21:00</option>
-  		<option value="22">22:00</option>
-  		<option value="23">23:00</option>
-	</select>
-
-	<INPUT TYPE="button" NAME="button" Value="View" onClick='setTime($("input#start").val(),$("input#end").val())'>
-	<INPUT TYPE="button" NAME="buttonreset" Value="Default" onClick='resetTime()'>
-
-
-	</form>
-
-<h3>Status of Active Files</h3>
-<div id="started"> Retriving Data... </div>
-<br>
-<h3>Status of Ended Files</h3>
-<div id="ended"> Retriving Data... </div>
-<br>
-<h3>Status of Killed and Resubmitted Files</h3>
-<div id="killed"> Retriving Data... </div>
-<br>
-	</div>
-
-  </div>
-  </body>
-
+    <head>
+        <title>AsyncTransfer Monitor System</title>
+        <link rel="stylesheet" href="style/main.css" type="text/css">
+        <script language="JavaScript" src="calendar_db.js"></script>
+        <link rel="stylesheet" href="calendar.css">
+    </head>
+    <body>
+    <div id="main">
+        <div id="head"><h2>AsyncTransfer Monitor System</h2></div>
+        <div id="sidebar"><p></p></div>
+        <div id="items">
+        <form name="datetimeform" id="datetimeform">
+        <!-- calendar attaches to existing form element -->
+        <a>&nbsp;&nbsp;Start Date&nbsp;</a>
+        <input type="text" id="start" value="" />
+        <script language="JavaScript">
+        var o_cal = new tcal ({
+                // form name
+                //'formname': 'testform',
+                // input name
+                'controlname': 'start'
+        });
+        // individual template parameters can be modified via the calendar variable
+        o_cal.a_tpl.yearscroll = true;
+        o_cal.a_tpl.weekstart = 1;
+        </script>
+        <a>&nbsp;&nbsp;Start Time&nbsp;</a>
+        <select id="starttime">
+                <option value="-1"></option>
+                <option value="0">00:00</option>
+                <option value="1">01:00</option>
+                <option value="2">02:00</option>
+                <option value="3">03:00</option>
+                <option value="4">04:00</option>
+                <option value="5">05:00</option>
+                <option value="6">06:00</option>
+                <option value="7">07:00</option>
+                <option value="8">08:00</option>
+                <option value="9">09:00</option>
+                <option value="10">10:00</option>
+                <option value="11">11:00</option>
+                <option value="12">12:00</option>
+                <option value="13">13:00</option>
+                <option value="14">14:00</option>
+                <option value="15">15:00</option>
+                <option value="16">16:00</option>
+                <option value="17">17:00</option>
+                <option value="18">18:00</option>
+                <option value="19">19:00</option>
+                <option value="20">20:00</option>
+                <option value="21">21:00</option>
+                <option value="22">22:00</option>
+                <option value="23">23:00</option>
+        </select>
+        <a>&nbsp;&nbsp;&nbsp;&nbsp;End Date&nbsp;</a>
+        <input type="text" name="testinput2" id="end" value="" />
+        <script language="JavaScript">
+        //var A_CALTPL = {
+        //      'months' : ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        //      'weekdays' : ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
+        //      'yearscroll': true,
+        //      'weekstart': 0,
+        //      'centyear'  : 70,
+        //      'imgpath' : 'img/'
+        //}
+        var e_cal = new tcal ({
+                // if referenced by ID then form name is not required
+                'controlname': 'end'
+        }); //, A_CALTPL);
+        e_cal.a_tpl.yearscroll = true;
+        e_cal.a_tpl.weekstart = 1;
+        </script>
+        <a>&nbsp;&nbsp;End Time&nbsp;</a>
+        <select id="endtime">
+                <option value="-1"></option>
+                <option value="0">00:00</option>
+                <option value="1">01:00</option>
+                <option value="2">02:00</option>
+                <option value="3">03:00</option>
+                <option value="4">04:00</option>
+                <option value="5">05:00</option>
+                <option value="6">06:00</option>
+                <option value="7">07:00</option>
+                <option value="8">08:00</option>
+                <option value="9">09:00</option>
+                <option value="10">10:00</option>
+                <option value="11">11:00</option>
+                <option value="12">12:00</option>
+                <option value="13">13:00</option>
+                <option value="14">14:00</option>
+                <option value="15">15:00</option>
+                <option value="16">16:00</option>
+                <option value="17">17:00</option>
+                <option value="18">18:00</option>
+                <option value="19">19:00</option>
+                <option value="20">20:00</option>
+                <option value="21">21:00</option>
+                <option value="22">22:00</option>
+                <option value="23">23:00</option>
+        </select>
+        &nbsp;&nbsp;&nbsp;&nbsp;<INPUT TYPE="button" NAME="buttonreset" Value="Default" onClick='resetDateTime();setOptions();drawchart()'>
+        </form>
+        <form name="yaxisform" id="yaxisform">
+        <a>&nbsp;&nbsp;Y-Axis Unit&nbsp;</a>
+        <select id="yaxis">
+                <option value="njobs" text="Number of Files">Number of Files</option>
+                <option value="size" text="Files Size (MB)">Files Size (MB)</option>
+        </select>
+        </form>
+        <center><INPUT TYPE="button" NAME="button" Value="Reload Plots" onClick='setOptions();drawchart()'></center>
+        <h3>Status of Active Files</h3>
+        <div id="started"> Retriving Data... </div>
+        <br>
+        <h3>Status of Ended Files</h3>
+        <div id="ended"> Retriving Data... </div>
+        <br>
+        <h3>Status of Killed and Resubmitted Files</h3>
+        <div id="killed"> Retriving Data... </div>
+        <br>
+        </div>
+    </div>
+    </body>
 
 <script src="vendor/couchapp/loader.js"></script>
-
-
 <script type="text/javascript" charset="utf-8">
 
-
-  $.couch.app(function(app) {
+$.couch.app(function(app) {
     $("#sidebar").evently("menu", app);
     $("#head").evently("head", app);
     //$("#items").evently("main", app);
-  });
-
-  $(document).ready(function() {
-	    drawchart();
-		setInterval(function() drawchart(), 60000);
 });
 
+$(document).ready(function() {
+    drawchart();
+    setInterval(function() drawchart(), 60000);
+});
 
 var timeSlice = 3600000;
 
@@ -165,166 +156,258 @@ inputes.status = ["resubmitted","killed"];
 
 var startd = new Date();
 var endd = new Date();
-var defaultTime = true;
+var defaultDateTime = true;
 
-function setTime(start, end){
-			var startdate = new Date(start);
-			startdate.setUTCHours($("#starttime").val());
-			var enddate = new Date(end);
-			enddate.setUTCHours($("#endtime").val());
-			if(enddate<startdate){
-				alert("Error: start time bigger than end time");
-			}else{
-				startd = startdate;
-				endd = enddate;
+var yaxis = ("njobs").toString();
+var MB = 1048576;
 
-				}
-				defaultTime = false;
-				drawchart();
-			}
+function isStartDateDefined() {
+    return ($("input#start").val() != '');
+}
 
-function resetTime(){
-	defaultTime = true;
-	drawchart();
+function isEndDateDefined() {
+    return ($("input#end").val() != '');
+}
 
-	}
+function isStartTimeDefined() {
+    return ($("#starttime").val() > -1);
+}
 
-function calcInterval(){
-	var now = new Date();
+function isEndTimeDefined() {
+    return ($("#endtime").val() > -1);
+}
+
+function isStartDateTimeDefined() {
+    return (isStartDateDefined() && isStartTimeDefined());
+}
+
+function isEndDateTimeDefined() {
+    return (isEndDateDefined() && isEndTimeDefined());
+}
+
+function getStartDate() {
+    if (isStartDateDefined()) {
+        return $("input#start").val();
+    }
+    var now = new Date();
+    return now.getDate()-1;
+}
+
+function getEndDate() {
+    if (isEndDateDefined()) {
+        return $("input#end").val();
+    }
+    var now = new Date();
+    return now.getDate();
+}
+
+function getStartTime() {
+    if (isStartTimeDefined()) {
+        return $("#starttime").val();
+    }
+    return 0;
+}
+
+function getEndTime() {
+    if (isEndTimeDefined()) {
+        return $("#endtime").val();
+    }
+    return 0;
+}
+
+function setDateTime() {
+    if (isStartDateTimeDefined() && isEndDateTimeDefined()) {
+        var startdate = new Date(getStartDate());
+        startdate.setUTCHours(getStartTime());
+        var enddate = new Date(getEndDate());
+        enddate.setUTCHours(getEndTime());
+        if (enddate < startdate) {
+            alert("Error: start date/time bigger than end date/time");
+        }
+        else {
+            startd = startdate;
+            endd = enddate;
+        }
+        defaultDateTime = false;
+    }
+    else {
+        resetDateTime();
+    }
+}
+
+function resetDateTime() {
+    defaultDateTime = true;
+    document.getElementById('datetimeform').reset();
+}
+
+function getYAxis() {
+    return ($("#yaxis").val()).toString();
+}
+
+function getYAxisLabel() {
+    if (getYAxis() == "njobs") {
+        return "Number of Files";
+    }
+    else if (getYAxis() == "size") {
+        return "Files Size (MB)";
+    }
+    return "";
+}
+
+function setYAxis() {
+    yaxis = getYAxis();
+}
+
+function setOptions() {
+    setDateTime();
+    setYAxis();
+}
+
+function calcInterval() {
+    var now = new Date();
     var start = new Date(now);
     start.setDate(start.getDate()-1);
-	startd = start;
-	endd = now;
-
-	}
-
-inpute.popolate = function(){
-		inpute.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-		var startkey =  [startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = [endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/endedByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var donefile = [];
-			var failfile = [];
-			var killfile=[];
-			for(i=0; i<=hours; i++){
-
-			var key = [tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var killF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00","value": 0};
-			var doneF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var failF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-				doneF.value= response[rs].value.done;
-				failF.value= response[rs].value.failed;
-				rs = rs+1;
-			}
-
-			donefile.push(doneF);
-			failfile.push(failF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inpute.stacked.push(donefile);
-		inpute.stacked.push(failfile);
+    startd = start;
+    endd = now;
 }
 
-inputs.popolate = function(){
-		inputs.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-			var startkey =  [startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = [endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/startedByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var newfile = [];
-			var acqfile = [];
-			for(i=0; i<=hours; i++){
-
-			var key = [tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var newF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var acqF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-				newF.value= response[rs].value.new;
-				acqF.value= response[rs].value.acquired;
-				rs = rs+1;
-			}
-			newfile.push(newF);
-			acqfile.push(acqF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inputs.stacked.push(newfile);
-		inputs.stacked.push(acqfile);
+function getDateTimeKey(DateObj,format) {
+    if (format != "axisTickLabel" && format != "view") format = "view";
+    if (format == "axisTickLabel") {
+        return DateObj.getUTCMonth()+1+"/"+DateObj.getUTCDate()+" "+DateObj.getUTCHours()+":00";
+    }
+    else if (format == "view") {
+        return [DateObj.getUTCFullYear(), DateObj.getUTCMonth()+1, DateObj.getUTCDate(), DateObj.getUTCHours()];
+    }
 }
 
-inputes.popolate = function(){
-                inputes.stacked = [];
-                var h = timeSlice;
-                var hours = (endd.getTime() - startd.getTime())/h;
-                var startkey =  [startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-                var endkey = [endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-                        xmlhttp = new XMLHttpRequest();
-                        xmlhttp.open("GET", "_view/endedByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey +"]", false);
-                        xmlhttp.send();
-                        var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-                        var rs = 0;
-                        var tslice = new Date(startd);
-                        var killfile = [];
-                        var empfile = [];
-                        for(i=0; i<=hours; i++){
+inpute.popolate = function() {
+    inpute.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view");
+    var endkey = getDateTimeKey(endd,"view");
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/endedSizeByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var donefile = [];
+    var failfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = getDateTimeKey(tslice,"view");
+        //alert(key.toString());
+        var doneF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        var failF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                doneF.value = response[rs].value.done.njobs;
+                failF.value = response[rs].value.failed.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                doneF.value = response[rs].value.done.size/MB;
+                failF.value = response[rs].value.failed.size/MB;
+            }
+            rs = rs+1;
+        }
+        donefile.push(doneF);
+        failfile.push(failF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inpute.stacked.push(donefile);
+    inpute.stacked.push(failfile);
+}
 
-                        var key = [tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()]
-;
-                        //alert(key.toString());
-                        var killF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00","value": 0};
-                        var empF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00","value": 0};
+inputs.popolate = function() {
+    inputs.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view");
+    var endkey = getDateTimeKey(endd,"view");
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/startedSizeByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var newfile = [];
+    var acqfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = getDateTimeKey(tslice,"view");
+        //alert(key.toString());
+        var newF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        var acqF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                newF.value = response[rs].value.new.njobs;
+                acqF.value = response[rs].value.acquired.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                newF.value = response[rs].value.new.size/MB;
+                acqF.value = response[rs].value.acquired.size/MB;
+            }
+            rs = rs+1;
+        }
+        newfile.push(newF);
+        acqfile.push(acqF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inputs.stacked.push(newfile);
+    inputs.stacked.push(acqfile);
+}
 
-                        if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-                                killF.value= response[rs].value.killed;
-                                empF.value=response[rs].value.resubmitted;
-				    rs = rs+1;
-                        }
-			empfile.push(empF);
-                        killfile.push(killF);
-                        tslice.setHours(tslice.getHours()+1);
-                        }
+inputes.popolate = function() {
+    inputes.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view");
+    var endkey = getDateTimeKey(endd,"view");
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/endedSizeByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey +"]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var killfile = [];
+    var empfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = getDateTimeKey(tslice,"view");
+        //alert(key.toString());
+        var killF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        var empF  = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                killF.value = response[rs].value.killed.njobs;
+                empF.value  = response[rs].value.resubmitted.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                killF.value = response[rs].value.killed.size/MB;
+                empF.value  = response[rs].value.resubmitted.size/MB;
+            }
+            rs = rs+1;
+        }
+        empfile.push(empF);
+        killfile.push(killF);
+        tslice.setHours(tslice.getHours()+1);
+    }
     inputes.stacked.push(empfile);
     inputes.stacked.push(killfile);
 }
 
-function drawchart(){
-
-	if(defaultTime){
-		calcInterval();
-	}
-	inputs.popolate();
-	inputes.popolate();
-	inpute.popolate();
-
-    setTimeout(function() stackedArea("started", inputs) , 1000 );
-    setTimeout(function() stackedArea("killed", inputes) , 1000 );
-    setTimeout(function() stackedArea("ended", inpute) , 1000 );
+function drawchart() {
+    if (defaultDateTime) {
+        calcInterval();
+    }
+    inputs.popolate();
+    inputes.popolate();
+    inpute.popolate();
+    setTimeout(function() stackedArea("started",inputs,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("killed",inputes,getYAxisLabel()),1000);
+    setTimeout(function() stackedArea("ended",inpute,getYAxisLabel()),1000);
 }
 
-
 </script>
-
 
 </html>
 

--- a/src/couchapp/monitor/_attachments/publish.html
+++ b/src/couchapp/monitor/_attachments/publish.html
@@ -1,144 +1,135 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <title>AsyncTransfer Monitor System</title>
-    <link rel="stylesheet" href="style/main.css" type="text/css">
-    <script language="JavaScript" src="calendar_db.js"></script>
-	<link rel="stylesheet" href="calendar.css">
-
-  </head>
-  <body>
-  <div id="main">
-    <div id="head"><h2>AsyncTransfer Monitor System</h2></div>
-
-
-    <div id="sidebar"><p></p></div>
-
-	<div id="items">
-
-	    <form name="selectionform">
-
-	<!-- calendar attaches to existing form element -->
-	<a>Start Date&nbsp;</a>
-	<input type="text" id="start" />
-	<script language="JavaScript">
-	var o_cal = new tcal ({
-		// form name
-		//'formname': 'testform',
-		// input name
-		'controlname': 'start'
-	});
-
-	// individual template parameters can be modified via the calendar variable
-	o_cal.a_tpl.yearscroll = false;
-	o_cal.a_tpl.weekstart = 1;
-
-	</script>
-	<a>Start Time</a>
-	<select id="starttime">
-  		<option value="0">00:00</option>
-  		<option value="1">01:00</option>
-  		<option value="2">02:00</option>
-  		<option value="3">03:00</option>
-  		<option value="4">04:00</option>
-		<option value="5">05:00</option>
-  		<option value="6">06:00</option>
-  		<option value="7">07:00</option>
-  		<option value="8">08:00</option>
-  		<option value="9">09:00</option>
-  		<option value="10">10:00</option>
-  		<option value="11">11:00</option>
-  		<option value="12">12:00</option>
-		<option value="13">13:00</option>
-  		<option value="14">14:00</option>
-  		<option value="15">15:00</option>
-  		<option value="16">16:00</option>
-  		<option value="17">17:00</option>
-  		<option value="18">18:00</option>
-  		<option value="19">19:00</option>
-  		<option value="20">20:00</option>
-		<option value="21">21:00</option>
-  		<option value="22">22:00</option>
-  		<option value="23">23:00</option>
-	</select>
-
-	<a>&nbsp;&nbsp;End Date&nbsp;</a>
-	<input type="text" name="testinput2" id="end" />
-	<script language="JavaScript">
-	var A_CALTPL = {
-		'months' : ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
-		'weekdays' : ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
-		'yearscroll': true,
-		'weekstart': 0,
-		'centyear'  : 70,
-		'imgpath' : 'img/'
-	}
-
-	new tcal ({
-		// if referenced by ID then form name is not required
-		'controlname': 'end'
-	}, A_CALTPL);
-	</script>
-	<a>End Time</a>
-	<select id="endtime">
-  		<option value="0">00:00</option>
-  		<option value="1">01:00</option>
-  		<option value="2">02:00</option>
-  		<option value="3">03:00</option>
-  		<option value="4">04:00</option>
-		<option value="5">05:00</option>
-  		<option value="6">06:00</option>
-  		<option value="7">07:00</option>
-  		<option value="8">08:00</option>
-  		<option value="9">09:00</option>
-  		<option value="10">10:00</option>
-  		<option value="11">11:00</option>
-  		<option value="12">12:00</option>
-		<option value="13">13:00</option>
-  		<option value="14">14:00</option>
-  		<option value="15">15:00</option>
-  		<option value="16">16:00</option>
-  		<option value="17">17:00</option>
-  		<option value="18">18:00</option>
-  		<option value="19">19:00</option>
-  		<option value="20">20:00</option>
-		<option value="21">21:00</option>
-  		<option value="22">22:00</option>
-  		<option value="23">23:00</option>
-	</select>
-
-	<INPUT TYPE="button" NAME="button" Value="View" onClick='setTime($("input#start").val(),$("input#end").val())'>
-	<INPUT TYPE="button" NAME="buttonreset" Value="Default" onClick='resetTime()'>
-
-
-	</form>
-
-<h3>Status of Publication</h3>
-<div id="started"> Retriving Data... </div>
-<br>
-	</div>
-
-  </div>
-  </body>
-
+    <head>
+        <title>AsyncTransfer Monitor System</title>
+        <link rel="stylesheet" href="style/main.css" type="text/css">
+        <script language="JavaScript" src="calendar_db.js"></script>
+        <link rel="stylesheet" href="calendar.css">
+    </head>
+    <body>
+    <div id="main">
+        <div id="head"><h2>AsyncTransfer Monitor System</h2></div>
+        <div id="sidebar"><p></p></div>
+        <div id="items">
+        <form name="datetimeform" id="datetimeform">
+        <!-- calendar attaches to existing form element -->
+        <a>&nbsp;&nbsp;Start Date&nbsp;</a>
+        <input type="text" id="start" value="" />
+        <script language="JavaScript">
+        var o_cal = new tcal ({
+                // form name
+                //'formname': 'testform',
+                // input name
+                'controlname': 'start'
+        });
+        // individual template parameters can be modified via the calendar variable
+        o_cal.a_tpl.yearscroll = true;
+        o_cal.a_tpl.weekstart = 1;
+        </script>
+        <a>&nbsp;&nbsp;Start Time&nbsp;</a>
+        <select id="starttime">
+                <option value="-1"></option>
+                <option value="0">00:00</option>
+                <option value="1">01:00</option>
+                <option value="2">02:00</option>
+                <option value="3">03:00</option>
+                <option value="4">04:00</option>
+                <option value="5">05:00</option>
+                <option value="6">06:00</option>
+                <option value="7">07:00</option>
+                <option value="8">08:00</option>
+                <option value="9">09:00</option>
+                <option value="10">10:00</option>
+                <option value="11">11:00</option>
+                <option value="12">12:00</option>
+                <option value="13">13:00</option>
+                <option value="14">14:00</option>
+                <option value="15">15:00</option>
+                <option value="16">16:00</option>
+                <option value="17">17:00</option>
+                <option value="18">18:00</option>
+                <option value="19">19:00</option>
+                <option value="20">20:00</option>
+                <option value="21">21:00</option>
+                <option value="22">22:00</option>
+                <option value="23">23:00</option>
+        </select>
+        <a>&nbsp;&nbsp;&nbsp;&nbsp;End Date&nbsp;</a>
+        <input type="text" name="testinput2" id="end" value="" />
+        <script language="JavaScript">
+        //var A_CALTPL = {
+        //      'months' : ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
+        //      'weekdays' : ['do', 'lu', 'ma', 'mi', 'ju', 'vi', 'sa'],
+        //      'yearscroll': true,
+        //      'weekstart': 0,
+        //      'centyear'  : 70,
+        //      'imgpath' : 'img/'
+        //}
+        var e_cal = new tcal ({
+                // if referenced by ID then form name is not required
+                'controlname': 'end'
+        }); //, A_CALTPL);
+        e_cal.a_tpl.yearscroll = true;
+        e_cal.a_tpl.weekstart = 1;
+        </script>
+        <a>&nbsp;&nbsp;End Time&nbsp;</a>
+        <select id="endtime">
+                <option value="-1"></option>
+                <option value="0">00:00</option>
+                <option value="1">01:00</option>
+                <option value="2">02:00</option>
+                <option value="3">03:00</option>
+                <option value="4">04:00</option>
+                <option value="5">05:00</option>
+                <option value="6">06:00</option>
+                <option value="7">07:00</option>
+                <option value="8">08:00</option>
+                <option value="9">09:00</option>
+                <option value="10">10:00</option>
+                <option value="11">11:00</option>
+                <option value="12">12:00</option>
+                <option value="13">13:00</option>
+                <option value="14">14:00</option>
+                <option value="15">15:00</option>
+                <option value="16">16:00</option>
+                <option value="17">17:00</option>
+                <option value="18">18:00</option>
+                <option value="19">19:00</option>
+                <option value="20">20:00</option>
+                <option value="21">21:00</option>
+                <option value="22">22:00</option>
+                <option value="23">23:00</option>
+        </select>
+        &nbsp;&nbsp;&nbsp;&nbsp;<INPUT TYPE="button" NAME="buttonreset" Value="Default" onClick='resetDateTime();setOptions();drawchart()'>
+        </form>
+        <form name="yaxisform" id="yaxisform">
+        <a>&nbsp;&nbsp;Y-Axis Unit&nbsp;</a>
+        <select id="yaxis">
+                <option value="njobs" text="Number of Files">Number of Files</option>
+                <option value="size" text="Files Size (MB)">Files Size (MB)</option>
+        </select>
+        </form>
+        <center><INPUT TYPE="button" NAME="button" Value="Reload Plots" onClick='setOptions();drawchart()'></center>
+        <h3>Status of Publication</h3>
+        <div id="started"> Retriving Data... </div>
+        <br>
+        </div>
+    </div>
+    </body>
 
 <script src="vendor/couchapp/loader.js"></script>
-
-
 <script type="text/javascript" charset="utf-8">
 
-
-  $.couch.app(function(app) {
+$.couch.app(function(app) {
     $("#sidebar").evently("menu", app);
     $("#head").evently("head", app);
     //$("#items").evently("main", app);
-  });
-
-  $(document).ready(function() {
-	    drawchart();
-		setInterval(function() drawchart(), 60000);
 });
 
+$(document).ready(function() {
+    drawchart();
+    setInterval(function() drawchart(), 60000);
+});
 
 var timeSlice = 3600000;
 
@@ -147,92 +138,180 @@ inpute.data = [];
 inpute.stacked = [];
 inpute.status = ["done","failed"];
 
+var startd = new Date();
 var endd = new Date();
-var defaultTime = true;
+var defaultDateTime = true;
 
-function setTime(start, end){
-			var startdate = new Date(start);
-			startdate.setUTCHours($("#starttime").val());
-			var enddate = new Date(end);
-			enddate.setUTCHours($("#endtime").val());
-			if(enddate<startdate){
-				alert("Error: start time bigger than end time");
-			}else{
-				startd = startdate;
-				endd = enddate;
+var yaxis = ("njobs").toString();
+var MB = 1048576;
 
-				}
-				defaultTime = false;
-				drawchart();
-			}
+function isStartDateDefined() {
+    return ($("input#start").val() != '');
+}
 
-function resetTime(){
-	defaultTime = true;
-	drawchart();
+function isEndDateDefined() {
+    return ($("input#end").val() != '');
+}
 
-	}
+function isStartTimeDefined() {
+    return ($("#starttime").val() > -1);
+}
 
-function calcInterval(){
-	var now = new Date();
+function isEndTimeDefined() {
+    return ($("#endtime").val() > -1);
+}
+
+function isStartDateTimeDefined() {
+    return (isStartDateDefined() && isStartTimeDefined());
+}
+
+function isEndDateTimeDefined() {
+    return (isEndDateDefined() && isEndTimeDefined());
+}
+
+function getStartDate() {
+    if (isStartDateDefined()) {
+        return $("input#start").val();
+    }
+    var now = new Date();
+    return now.getDate()-1;
+}
+
+function getEndDate() {
+    if (isEndDateDefined()) {
+        return $("input#end").val();
+    }
+    var now = new Date();
+    return now.getDate();
+}
+
+function getStartTime() {
+    if (isStartTimeDefined()) {
+        return $("#starttime").val();
+    }
+    return 0;
+}
+
+function getEndTime() {
+    if (isEndTimeDefined()) {
+        return $("#endtime").val();
+    }
+    return 0;
+}
+
+function setDateTime() {
+    if (isStartDateTimeDefined() && isEndDateTimeDefined()) {
+        var startdate = new Date(getStartDate());
+        startdate.setUTCHours(getStartTime());
+        var enddate = new Date(getEndDate());
+        enddate.setUTCHours(getEndTime());
+        if (enddate < startdate) {
+            alert("Error: start date/time bigger than end date/time");
+        }
+        else {
+            startd = startdate;
+            endd = enddate;
+        }
+        defaultDateTime = false;
+    }
+    else {
+        resetDateTime();
+    }
+}
+
+function resetDateTime() {
+    defaultDateTime = true;
+    document.getElementById('datetimeform').reset();
+}
+
+function getYAxis() {
+    return ($("#yaxis").val()).toString();
+}
+
+function getYAxisLabel() {
+    if (getYAxis() == "njobs") {
+        return "Number of Files";
+    }
+    else if (getYAxis() == "size") {
+        return "Files Size (MB)";
+    }
+    return "";
+}
+
+function setYAxis() {
+    yaxis = getYAxis();
+}
+
+function setOptions() {
+    setDateTime();
+    setYAxis();
+}
+
+function calcInterval() {
+    var now = new Date();
     var start = new Date(now);
     start.setDate(start.getDate()-1);
-	startd = start;
-	endd = now;
-
-	}
-
-inpute.popolate = function(){
-		inpute.stacked = [];
-		var h = timeSlice;
-		var hours = (endd.getTime() - startd.getTime())/h;
-		var startkey =  [startd.getUTCFullYear(), startd.getUTCMonth()+1, startd.getUTCDate(), startd.getUTCHours()];
-			var endkey = [endd.getUTCFullYear(), endd.getUTCMonth()+1, endd.getUTCDate(), endd.getUTCHours()];
-			xmlhttp = new XMLHttpRequest();
-  			xmlhttp.open("GET", "_view/publicationState?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
-  			xmlhttp.send();
-                	var response = eval("(" + xmlhttp.responseText + ")")["rows"];
-			var rs = 0;
-			var tslice = new Date(startd);
-			var donefile = [];
-			var failfile = [];
-			var killfile=[];
-			for(i=0; i<=hours; i++){
-
-			var key = [tslice.getUTCFullYear(), tslice.getUTCMonth()+1, tslice.getUTCDate(), tslice.getUTCHours()];
-			//alert(key.toString());
-			var doneF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-			var failF = {"time": tslice.getUTCMonth()+1+"/"+tslice.getUTCDate()+" "+tslice.getUTCHours()+":00",
-				"value": 0};
-
-			if((rs<response.length)&&(key.toString() == response[rs].key.toString())){
-				doneF.value= response[rs].value.published;
-				failF.value= response[rs].value.not_published;
-				rs = rs+1;
-			}
-
-			donefile.push(doneF);
-			failfile.push(failF);
-			tslice.setHours(tslice.getHours()+1);
-			}
-		inpute.stacked.push(donefile);
-		inpute.stacked.push(failfile);
+    startd = start;
+    endd = now;
 }
 
-
-function drawchart(){
-
-	if(defaultTime){
-		calcInterval();
-	}
-	inpute.popolate();
-
-    setTimeout(function() stackedArea("started", inpute) , 1000 );
+function getDateTimeKey(DateObj,format) {
+    if (format != "axisTickLabel" && format != "view") format = "view";
+    if (format == "axisTickLabel") {
+        return DateObj.getUTCMonth()+1+"/"+DateObj.getUTCDate()+" "+DateObj.getUTCHours()+":00";
+    }
+    else if (format == "view") {
+        return [DateObj.getUTCFullYear(), DateObj.getUTCMonth()+1, DateObj.getUTCDate(), DateObj.getUTCHours()];
+    }
 }
 
+inpute.popolate = function() {
+    inpute.stacked = [];
+    var h = timeSlice;
+    var hours = (endd.getTime() - startd.getTime())/h;
+    var startkey = getDateTimeKey(startd,"view");
+    var endkey = getDateTimeKey(endd,"view");
+    xmlhttp = new XMLHttpRequest();
+    xmlhttp.open("GET", "_view/publicationStateSizeByTime?stale=ok&group_level=4&startkey=[" + startkey + "]&endkey=[" + endkey + "]", false);
+    xmlhttp.send();
+    var response = eval("(" + xmlhttp.responseText + ")")["rows"];
+    var rs = 0;
+    var tslice = new Date(startd);
+    var donefile = [];
+    var failfile = [];
+    for (i=0; i<=hours; i++) {
+        var key = getDateTimeKey(tslice,"view");
+        //alert(key.toString());
+        var doneF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        var failF = {"time": getDateTimeKey(tslice,"axisTickLabel"),"value": 0};
+        if ((rs<response.length)&&(key.toString() == response[rs].key.toString())) {
+            if (yaxis == ("njobs").toString()) {
+                doneF.value = response[rs].value.published.njobs;
+                failF.value = response[rs].value.not_published.njobs;
+            }
+            if (yaxis == ("size").toString()) {
+                doneF.value = response[rs].value.published.size/MB;
+                failF.value = response[rs].value.not_published.size/MB;
+            }
+            rs = rs+1;
+        }
+        donefile.push(doneF);
+        failfile.push(failF);
+        tslice.setHours(tslice.getHours()+1);
+    }
+    inpute.stacked.push(donefile);
+    inpute.stacked.push(failfile);
+}
+
+function drawchart() {
+    if (defaultDateTime) {
+        calcInterval();
+    }
+    inpute.popolate();
+    setTimeout(function() stackedArea("started",inpute,getYAxisLabel()),1000);
+}
 
 </script>
-
 
 </html>
 

--- a/src/couchapp/monitor/vendor/plots/_attachments/plots.js
+++ b/src/couchapp/monitor/vendor/plots/_attachments/plots.js
@@ -552,7 +552,7 @@ function update(i) {
 
 }
 
-function stackedArea(canvas, input) {
+function stackedArea(canvas, input, yaxislabel) {
 
 
 var tr = clone(input.stacked);
@@ -621,18 +621,16 @@ var area = vis.add(pv.Layout.Stack)
     .lineWidth(1)
     .bottom(0);
 
-
-
 root.add(pv.Label)
   .font("bold 13px sans-serif")
   .bottom(h/3)
-  .left(20)
+  .left(15)
   .textAngle(1.5 * Math.PI)
-  .text("Number of Files")
+  .text(yaxislabel)
 
 root.add(pv.Label)
   .font("bold 13px sans-serif")
-  .bottom(5)
+  .bottom(0)
   .left(w/2)
   .text("UTC Time")
 


### PR DESCRIPTION
In pull request #4158 I created seven new views that provide the size of the files (and the file count) for transfers and publication. Here I updated the monitoring to use these new views when doing the plots in the index.html, publish.html and dest-source-stat.html. 
IMPORTANT: the current patch requires patch #4158 to be applied aswell.
There is now a menu from where the user can choose the quantity used in the y axis for the plots. The options are: 1) the files counts (as it was before), and 2) the files size in MB. I also added a new button "Reload Plots" that onclick will read all the options in the form (start/end date/time and the y axis unit) and then calls drawchart(). There is now a function setOptions() that (as the name says) sets all the options (so far start/end date/time and y axis unit) before plotting. This function is called always before calling drawchart(). In this way the setting of the options and the plotting are now separate from each other. 
I also improved the way the date/time form is presented and used. For example, under a click on the "Default" button the date/time form is reset to blank, the flag defaultDateTime is set to true, and then the functions setOptions() and drawchart() are called. The setOptions() function reads the date/time form and the y axis form; if at least one date/time field is empty (i.e. not set) in the form, then the function sets the defaultDateTime flag to true and resets the date/time to blank; if all the fields are filled then the plots are done using the specified start/end date/time. To me this looks much more cleaner to the user.
