### PR TITLE
AttributeError: DbsApi object has no attribute api

### DIFF
--- a/src/python/AsyncStageOut/PublisherWorker.py
+++ b/src/python/AsyncStageOut/PublisherWorker.py
@@ -588,7 +588,7 @@ class PublisherWorker:
                 return []
             elif state == 2:
                 self.logger.info("Migration of %s is complete." % inputDataset)
-                existing_datasets = destReadApi.api.listDatasets(dataset=inputDataset, detail=True, dataset_access_type='*')
+                existing_datasets = destReadApi.listDatasets(dataset=inputDataset, detail=True, dataset_access_type='*')
             else:
                 self.logger.info("Migration of %s has taken too long - will delay publication." % inputDataset)
                 return []


### PR DESCRIPTION
INFO:DBSPublisher-Worker-sisagir:Migration of /DYJetsToLL_M-50_HT-100to200_Tune4C_13TeV-madgraph-tauola/Spring14dr-PU_S14_POSTLS170_V6-v1/AODSIM is complete.
ERROR:DBSPublisher-Worker-sisagir:'DbsApi' object has no attribute 'api'Traceback (most recent call last):
  File "/data/srv/asyncstageout/v1.0.2pre3/sw.pre/slc5_amd64_gcc461/cms/asyncstageout/1.0.2pre3/lib/python2.6/site-packages/AsyncStageOut/PublisherWorker.py", line 658, in publishInDBS3
    existing_datasets = self.migrateDBS3(migrateApi, destReadApi, sourceURL, inputDataset)
  File "/data/srv/asyncstageout/v1.0.2pre3/sw.pre/slc5_amd64_gcc461/cms/asyncstageout/1.0.2pre3/lib/python2.6/site-packages/AsyncStageOut/PublisherWorker.py", line 591, in migrateDBS3
    existing_datasets = destReadApi.api.listDatasets(dataset=inputDataset, detail=True, dataset_access_type='*')
AttributeError: 'DbsApi' object has no attribute 'api'
