### PR TITLE
First 14 views using erlang. Don`t merge

### DIFF
--- a/src/couchapp/AsyncTransfer/language
+++ b/src/couchapp/AsyncTransfer/language
@@ -1,1 +1,1 @@
-javascript
+erlang

--- a/src/couchapp/AsyncTransfer/views/JobsIdsStatesByWorkflow/map.js
+++ b/src/couchapp/AsyncTransfer/views/JobsIdsStatesByWorkflow/map.js
@@ -1,5 +1,12 @@
-function(doc) {
-	if(doc.workflow){
-		emit(doc.workflow, {'jobid': doc.jobid, 'state': doc.state});
-	}
-}
+fun({Doc}) ->
+  Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+  case Workflow of
+    _ ->
+      JobId = proplists:get_value(<<"jobid">>, Doc, null),
+      State = proplists:get_value(<<"state">>, Doc, null),
+      Emit(Workflow, {[{<<"jobid">>, JobId},{<<"state">>, State}]});
+    undefined -> ok;
+    <<"">> -> ok;
+    null -> ok
+  end
+end.

--- a/src/couchapp/AsyncTransfer/views/JobsStatesByWorkflow/map.js
+++ b/src/couchapp/AsyncTransfer/views/JobsStatesByWorkflow/map.js
@@ -1,5 +1,11 @@
-function(doc) {
-	if(doc.workflow){
-		emit(doc.workflow, doc.state);
-	}
-}
+fun({Doc}) ->
+  Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+  case Workflow of
+    _ ->
+      State = proplists:get_value(<<"state">>, Doc, null),
+      Emit(Workflow, State);
+    undefined -> ok;
+    <<"">> -> ok;
+    null -> ok
+  end
+end.

--- a/src/couchapp/AsyncTransfer/views/LFNSiteByLastUpdate/map.js
+++ b/src/couchapp/AsyncTransfer/views/LFNSiteByLastUpdate/map.js
@@ -1,19 +1,21 @@
-function complete_job(doc, req) {
-	if ( doc['state'] != 'done' ) {
-        	return false;
-        }
-        return true;
-}
-
-function(doc) {
-	if(doc.lfn && complete_job(doc)){
-                if (doc.lfn.indexOf("temp") > 0) {
-		        var lfn = doc.lfn
-                }
-                else {
-			var final_lfn = doc.lfn
-                	var lfn = final_lfn.replace('/store/user', '/store/temp/user')
-		}
-		emit(doc.last_update, {"lfn": lfn, "location": doc.source});
-	}
-}
+fun({Doc}) ->
+  State = proplists:get_value(<<"state">>, Doc, null),
+  case State of
+    <<"done">> ->
+      Lfn = proplists:get_value(<<"lfn">>, Doc, null),
+      case Lfn of
+        undefined -> ok;
+        <<"">> -> ok;
+        null -> ok;
+        _ ->
+          Nlfn = re:replace(Lfn,"/store/user","/store/temp/user",[{return,list}]),
+          Last_update = proplists:get_value(<<"last_update">>, Doc, null),
+          Source = proplists:get_value(<<"source">>, Doc, null),
+          Emit(Last_update, {[{<<"lfn">>, Nlfn},{<<"location">>, Source}]})
+      end;
+    _ -> ok;
+    undefined -> ok;
+    <<"">> -> ok;
+    null -> ok
+  end
+end.

--- a/src/couchapp/AsyncTransfer/views/PublicationStateByWorkflow/map.js
+++ b/src/couchapp/AsyncTransfer/views/PublicationStateByWorkflow/map.js
@@ -1,5 +1,12 @@
-function(doc) {
-	if(doc.publish == 1 && doc.type == 'output'){
-		emit(doc.workflow, doc.publication_state);
-	}
-}
+fun({Doc}) ->
+  Type = proplists:get_value(<<"type">>, Doc, null),
+  case Type of
+    <<"output">> ->
+      Publish = proplists:get_value(<<"publish">>, Doc, null),
+      case Publish of
+        1 ->
+          PubState = proplists:get_value(<<"publication_state">>, Doc, null),
+          Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+          Emit(Workflow, PubState);
+        _ -> ok; undefined -> ok; <<"">> -> ok; null -> ok end;
+    _ -> ok; undefined -> ok; <<"">> -> ok; null -> ok end end.

--- a/src/couchapp/AsyncTransfer/views/UserByStartTime/map.js
+++ b/src/couchapp/AsyncTransfer/views/UserByStartTime/map.js
@@ -1,5 +1,15 @@
-function(doc) {
-        if (doc.state != 'failed' && doc.state != 'done' && doc.lfn) {
-                emit([doc.user, doc.group, doc.role, doc.start_time.split('.')[0]], 1);
-        }
-}
+fun({Doc}) ->
+  Lfn = proplists:get_value(<<"lfn">>, Doc, null),
+  case Lfn of
+    _ -> 
+      State = proplists:get_value(<<"state">>, Doc, null),
+      case State of
+        <<"done">> -> ok; <<"failed">> -> ok;
+        _ -> 
+           User = proplists:get_value(<<"user">>, Doc, null),
+           Group = proplists:get_value(<<"group">>, Doc, null),
+           Role = proplists:get_value(<<"role">>, Doc, null),
+           Time = proplists:get_value(<<"start_time">>, Doc, null),
+           Emit([User, Group, Role, Time], 1);
+        undefined -> ok; <<"">> -> ok; null -> ok end;
+    undefined -> ok; <<"">> -> ok; null -> ok end end.

--- a/src/couchapp/AsyncTransfer/views/forKill/map.js
+++ b/src/couchapp/AsyncTransfer/views/forKill/map.js
@@ -1,5 +1,20 @@
-function(doc) {
-	if (doc.workflow && (doc.state=='new' || doc.state=='acquired' || doc.state=='retry')){
-		emit(doc.workflow,doc._id);
-	}
-}
+fun({Doc}) ->
+  Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+  case Workflow of
+    undefined -> ok;
+    <<"">> -> ok;
+    null -> ok;
+    _ -> 
+      State = proplists:get_value(<<"state">>, Doc, null),
+      Id = proplists:get_value(<<"_id">>, Doc, null),
+      case State of
+        undefined -> ok;
+        <<"">> -> ok;
+        null -> ok;
+        <<"new">> -> Emit(Workflow, Id);
+        <<"acquired">> -> Emit(Workflow, Id);
+        <<"retry">> -> Emit(Workflow, Id);
+        _ -> ok
+    end
+  end
+end.

--- a/src/couchapp/AsyncTransfer/views/forResub/map.js
+++ b/src/couchapp/AsyncTransfer/views/forResub/map.js
@@ -1,5 +1,19 @@
-function(doc) {
-	if (doc.workflow && (doc.state=='failed'||doc.state=='killed')){
-		emit(doc.workflow, doc._id);
-	}
-}
+fun({Doc}) ->
+  Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+  case Workflow of
+    undefined -> ok;
+    <<"">> -> ok;
+    null -> ok;
+    _ ->
+      State = proplists:get_value(<<"state">>, Doc, null),
+      Id = proplists:get_value(<<"_id">>, Doc, null),
+      case State of
+        <<"failed">> -> Emit(Workflow, Id);
+        <<"killed">> -> Emit(Workflow, Id);
+        undefined -> ok;
+        <<"">> -> ok;
+        null -> ok;
+        _ -> ok
+    end
+  end
+end.

--- a/src/couchapp/AsyncTransfer/views/ftscp_all/map.js
+++ b/src/couchapp/AsyncTransfer/views/ftscp_all/map.js
@@ -1,5 +1,23 @@
-function(doc) {
-        if (doc.state == 'new' && doc.lfn) {
-		emit([doc.user, doc.group, doc.role, doc.destination, doc.source], doc.lfn);
-	}
-}
+fun({Doc}) ->
+  State = proplists:get_value(<<"state">>, Doc, null),
+  case State of
+    <<"new">> ->
+      Lfn = proplists:get_value(<<"lfn">>, Doc, null),
+      case Lfn of
+         _ -> 
+           User = proplists:get_value(<<"user">>, Doc, null),
+           Group = proplists:get_value(<<"group">>, Doc, null),
+           Role = proplists:get_value(<<"role">>, Doc, null),
+           Dest = proplists:get_value(<<"destination">>, Doc, null),
+           Source = proplists:get_value(<<"source">>, Doc, null),
+           Emit([User, Group, Role, Dest, Source], Lfn);
+        undefined -> ok;
+        <<"">> -> ok;
+        null -> ok
+      end;
+    undefined -> ok;
+    <<"">> -> ok;
+    _ -> ok;
+    null -> ok
+  end
+end.

--- a/src/couchapp/AsyncTransfer/views/ftscp_all/reduce.js
+++ b/src/couchapp/AsyncTransfer/views/ftscp_all/reduce.js
@@ -1,1 +1,3 @@
-_count
+fun(Keys, Values, ReReduce) ->
+  length(Values)
+end.

--- a/src/couchapp/AsyncTransfer/views/getFilesToRetry/map.js
+++ b/src/couchapp/AsyncTransfer/views/getFilesToRetry/map.js
@@ -1,5 +1,20 @@
-function(doc) {
-	if (doc.state == 'retry' && doc.lfn) {
-		emit(doc._id, doc.last_update);
-	}
-}
+fun({Doc}) ->
+  State = proplists:get_value(<<"state">>, Doc, null),
+  case State of
+    <<"retry">> ->
+      Lfn = proplists:get_value(<<"lfn">>, Doc, null),
+      case Lfn of
+        _ ->   
+          Id = proplists:get_value(<<"_id">>, Doc, null),
+          LastUpdate = proplists:get_value(<<"last_update">>, Doc, null),
+          Emit(Id, LastUpdate);
+        undefined -> ok;
+        null -> ok;
+        <<"">> -> ok
+      end;
+    <<"">> -> ok;
+    undefined -> ok;
+    null -> ok;
+    _ -> ok
+  end
+end.

--- a/src/couchapp/DBSPublisher/language
+++ b/src/couchapp/DBSPublisher/language
@@ -1,1 +1,1 @@
-javascript
+erlang

--- a/src/couchapp/DBSPublisher/views/PublicationFailedByWorkflow/map.js
+++ b/src/couchapp/DBSPublisher/views/PublicationFailedByWorkflow/map.js
@@ -1,7 +1,11 @@
-function(doc) {
-	if(doc.workflow){
-		if(doc.publication_state=='publication_failed'){
-			emit(doc.workflow, doc._id);
-		}
-	}
-}
+fun({Doc}) ->
+  Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+  case Workflow of
+    _ -> 
+      Publication_state = proplists:get_value(<<"publication_state">>, Doc, null),
+      case Publication_state of
+        <<"pulication_failed">> -> 
+          Id = proplists:get_value(<<"_id">>, Doc, null),
+          Emit(Workflow, Id);
+        _ -> ok; undefined -> ok; <<"">> -> ok; null -> ok end;
+    undefined -> ok; <<"">> -> ok; null -> ok end end.

--- a/src/couchapp/DBSPublisher/views/publish/map.js
+++ b/src/couchapp/DBSPublisher/views/publish/map.js
@@ -1,17 +1,29 @@
-function(doc) {
-
-        if (doc.publication_state != 'published' && doc.publication_state != 'publication_failed' && doc.state == 'done' && doc.lfn && doc.dbs_url) {
-                var lfn = doc.lfn.replace('store', 'store/temp')
-                var publish = 0
-                if (doc.publish == 1) {
-                        publish = doc.publish
-                }
-                if (doc.type != 'log'){
-                        if (publish == 1){
-                                var dbs_url = doc.dbs_url
-                                        emit([doc.user, doc.group, doc.role, doc.workflow], [doc.destination, lfn, doc.inputdataset, dbs_url, doc.end_time.split('.')[0]]);
-                        }
-                }
-        }
-}
-
+fun({Doc}) ->
+  Publication_state = proplists:get_value(<<"publication_state">>, Doc, null),
+  case Publication_state of
+    <<"published">> -> ok; <<"publication_failed">> -> ok;
+    _ ->
+      State = proplists:get_value(<<"state">>, Doc, null),
+      case State of
+      <<"Done">> -> 
+        Publish = proplists:get_value(<<"dbs_url">>, Doc, null),
+        case Publish of
+          1 -> 
+            Type = proplists:get_value(<<"type">>, Doc, null),
+            case Type of
+              <<"log">> -> ok;
+              _ -> 
+                User = proplists:get_value(<<"user">>, Doc, null),
+                Lfn = proplists:get_value(<<"lfn">>, Doc, null),
+                Dbs = proplists:get_value(<<"dbs_url">>, Doc, null),
+                Group = proplists:get_value(<<"group">>, Doc, null),
+                Role = proplists:get_value(<<"role">>, Doc, null),
+                Workflow = proplists:get_value(<<"workflow">>, Doc, null),
+                Destination = proplists:get_value(<<"destination">>, Doc, null),
+                InputDataset = proplists:get_value(<<"inputdataset">>, Doc, null),
+                EndTime = proplists:get_value(<<"end_time">>, Doc, null), % Need to split!!!!!!
+                Emit([User, Group, Role, Workflow], [Destination, Lfn, InputDataset, Dbs, EndTime]);
+              undefined -> ok; <<"">> -> ok; null -> ok end;
+          _ -> ok; undefined -> ok; <<"">> -> ok; null -> ok end;
+      _ -> ok; undefined -> ok; <<"">> -> ok; null -> ok end;
+    undefined -> ok; <<"">> -> ok; null -> ok end end.

--- a/src/couchapp/DBSPublisher/views/publish/reduce.js
+++ b/src/couchapp/DBSPublisher/views/publish/reduce.js
@@ -1,1 +1,8 @@
-_count
+fun(Keys, Values, ReReduce) ->
+  case ReReduce of
+    _ -> length(Values);
+    undefined -> length(Values);
+    <<"">> -> length(Values);
+    null -> length(Values)
+  end
+end.

--- a/src/couchapp/monitor/views/endedSizeByTime/map.js
+++ b/src/couchapp/monitor/views/endedSizeByTime/map.js
@@ -1,26 +1,25 @@
-function(doc) {
-    if (doc.end_time) {
-        var start = doc.end_time;
-        var day  = start.split(' ')[0];
-        var time = start.split(' ')[1];
-        var yy = day.split('-')[0];
-        var mm = parseInt(day.split('-')[1], 10) - 1;
-        var dd = day.split('-')[2];
-        var h = time.split(':')[0];
-        var m = time.split(':')[1];
-        var s = time.split(':')[2].split('.')[0];
-        var startDate = new Date(yy, mm, dd, h, m, s);
-        yy_utc = startDate.getUTCFullYear();
-        mm_utc = startDate.getUTCMonth();
-        dd_utc = startDate.getUTCDate();
-        h_utc  = startDate.getUTCHours();
-        m_utc  = startDate.getUTCMinutes();
-        s_utc  = startDate.getUTCSeconds();
-        if (doc.state=='new'||doc.state=='retry') {
-            emit([yy_utc, mm_utc + 1, dd_utc, h_utc, m_utc, s_utc], {"state": 'resubmitted', "size": doc.size});
-        }
-        else {
-            emit([yy_utc, mm_utc + 1, dd_utc, h_utc, m_utc, s_utc], {"state": doc.state, "size": doc.size});
-        }
-    }
-}
+fun({Doc}) ->
+  EndTime = proplists:get_value(<<"end_time">>, Doc, null),
+  case EndTime of
+    null -> ok;
+    <<"">> -> ok;
+    undefined -> ok;
+    _ -> 
+      [Year, Month, Day, Hours, Min, Sec, Milli] = string:tokens(EndTime, "- :." ),
+      State = proplists:get_value(<<"state">>, Doc, null),
+      Size = proplists:get_value(<<"size">>, Doc, null),
+      case State of
+        undefined -> ok;
+        null -> ok;
+        <<"">> -> ok;
+        <<"new">> -> 
+          State = "resubmitted",
+          Emit([Year, Month, Day, Hours, Min, Sec], {[{<<"state">>, State},{<<"size">>,Size}]});
+        <<"retry">> ->
+          State = "resubmitted",
+          Emit([Year, Month, Day, Hours, Min, Sec], {[{<<"state">>, State},{<<"size">>,Size}]});
+        _ -> 
+          Emit([Year, Month, Day, Hours, Min, Sec], {[{<<"state">>, State},{<<"size">>,Size}]})
+      end
+  end
+end.


### PR DESCRIPTION
Here are first 14 views rewritten to erlang. Its still missing 3 views to be rewriten :

JobsIdsStatesByWorkflow (reduce)
PublicationStateByWorkflow (reduce)
endedSizeByTime (reduce)

monitoring views are ignored, which are not needed for transfers. More details in hypernews...
