### PR TITLE
Use destReadApi instead of destApi to get the parent files already present in destination DBS.

### DIFF
--- a/src/python/AsyncStageOut/PublisherWorker.py
+++ b/src/python/AsyncStageOut/PublisherWorker.py
@@ -680,7 +680,7 @@ class PublisherWorker:
 
             # Find any files already in the dataset so we can skip them
             try:
-                existingDBSFiles = destApi.listFiles(dataset=dbsDatasetPath)
+                existingDBSFiles = destReadApi.listFiles(dataset=dbsDatasetPath)
                 existingFiles = [x['logical_file_name'] for x in existingDBSFiles]
                 results[datasetPath]['existingFiles'] = len(existingFiles)
             except Exception, ex:


### PR DESCRIPTION
CRAB2 uses destReadApi (https://github.com/dmwm/CRAB2/blob/master/python/crab_dbs3publish.py#L273), and I would say it is the correct API to use. 
CRAB2 was using destApi until Feb 9, 2014: https://github.com/dmwm/CRAB2/blob/22f93190503ffedbd45f4b07a0b56094b7cf442a/python/crab_dbs3publish.py. Then Stefano changed it to destReadApi in this commit: https://github.com/dmwm/CRAB2/commit/d9dc9caa028907dd61df5fb0f452c71e3a20e10c

I was going to include this change in my big commit for migrating all parents, but I prefer to do it separately, because is kind of an unrelated bug fix (well, I am not sure if it is really a bug, because somehow the current code is working...).