### PR TITLE
Another fix for 'job failed/done' issues

### DIFF
--- a/src/Monitor/monitor.conf
+++ b/src/Monitor/monitor.conf
@@ -39,7 +39,7 @@ fake_transfer_script = /afs/cern.ch/user/w/wildish/public/COMP/PHEDEX_GIT/Testbe
 fake_transfer_rate = 104857600 # 1048576 is 1 MB/sec
 #fake_transfer_map = /path/to/map/file
 
-verbose = 1
+verbose = 0
 # debug   = 1
 
 #
@@ -49,7 +49,8 @@ verbose = 1
 # nodaemon = 1
 
 # Dump a logfile for each FTS job. Comment out unless you're debugging the source code!
-# job_logs = /data/wildish/dropbox/monitor/logs
+job_logs = /data/wildish/dropbox/monitor/logs
+# log_all_jobs # if job_logs is set, do I log all jobs, or only failures?
 
 # for more debugging information about the Monitor workflow
 # debug_jobs = 1

--- a/src/Monitor/perl_lib/ASO/File.pm
+++ b/src/Monitor/perl_lib/ASO/File.pm
@@ -58,8 +58,7 @@ our %exit_states =
 	  abandoned     => 2,
 	);
 
-sub new
-{
+sub new {
   my $proto = shift;
   my $class = ref($proto) || $proto;
   my $self  = ref($proto) ? $class->SUPER::new(@_) : {};
@@ -79,8 +78,7 @@ sub new
   return $self;
 }
 
-sub AUTOLOAD
-{
+sub AUTOLOAD {
   my $self = shift;
   my $attr = our $AUTOLOAD;
   $attr =~ s/.*:://;
@@ -98,8 +96,7 @@ sub AUTOLOAD
   $self->$parent(@_);
 }
 
-sub Log
-{
+sub Log {
   my $self = shift;
   push @{$self->{LOG}}, join(' ',@_,"\n") if @_;
 
@@ -108,8 +105,7 @@ sub Log
   return join('',@{$self->{LOG}});
 }
 
-sub State
-{
+sub State {
   my ($self,$state,$time) = @_;
   return $self->{STATE} unless $state;
   return undef if ( $state eq $self->{STATE} );
@@ -122,8 +118,7 @@ sub State
 
 sub ExitStates { return \%ASO::File::exit_states; }
 
-sub Retry
-{
+sub Retry {
   my $self = shift;
   $self->{RETRIES}++;
   return 0 if $self->{RETRIES} >= $self->{MAX_TRIES};
@@ -132,21 +127,18 @@ sub Retry
   return $self->{RETRIES};
 }
 
-sub Retries
-{
+sub Retries {
   my $self = shift;
   return $self->{RETRIES};
 }
 
-sub Nice
-{
+sub Nice {
   my $self = shift;
   my $nice = shift || -4;
   $self->{PRIORITY} += $nice;
 }
 
-sub WriteLog
-{
+sub WriteLog {
   my $self = shift;
   my $dir = shift;
   return unless $dir;
@@ -164,114 +156,98 @@ sub WriteLog
   close $fh;
 }
 
-sub Timeout
-{
+sub Timeout {
   my $self = shift;
   $self->{TIMEOUT} = shift if @_;
   return $self->{TIMEOUT};
 }
 
-sub Priority
-{
+sub Priority {
   my $self = shift;
   $self->{PRIORITY} = shift if @_;
   return $self->{PRIORITY};
 }
 
-sub MaxTries
-{
+sub MaxTries {
   my $self = shift;
   $self->{MAX_TRIES} = shift if @_;
   return $self->{MAX_TRIES};
 }
 
-sub Source
-{
+sub Source {
   my $self = shift;
   $self->{SOURCE} = shift if @_;
   return $self->{SOURCE};
 }
 
-sub ChecksumType
-{
+sub ChecksumType {
   my $self = shift;
   $self->{CHECKSUM_TYPE} = shift if @_;
   return $self->{CHECKSUM_TYPE};
 }
 
-sub ChecksumValue
-{
+sub ChecksumValue {
   my $self = shift;
   $self->{CHECKSUM_VAL} = shift if @_;
   return $self->{CHECKSUM_VAL};
 }
 
-sub Destination
-{
+sub Destination {
   my $self = shift;
   $self->{DESTINATION} = shift if @_;
   return $self->{DESTINATION};   
 }
 
-sub TaskID
-{
+sub TaskID {
   my $self = shift;
   $self->{TASKID} = shift if @_;
   $self->{ME} = $self->{TASKID};
   return $self->{TASKID};
 }
 
-sub FromNode
-{
+sub FromNode {
   my $self = shift;
   $self->{FROM_NODE} = shift if @_;
   return $self->{FROM_NODE};
 }
 
-sub ToNode
-{
+sub ToNode {
   my $self = shift;
   $self->{TO_NODE} = shift if @_;
   return $self->{TO_NODE};
 }
 
-sub Workdir
-{
+sub Workdir {
   my $self = shift;
   $self->{WORKDIR} = shift if @_;
   return $self->{WORKDIR};
 }
 
-sub Timestamp
-{
+sub Timestamp {
   my $self = shift;
   $self->{TIMESTAMP} = shift if @_;
   return $self->{TIMESTAMP};
 }
 
-sub Reason
-{
+sub Reason {
   my $self = shift;
   $self->{REASON} = shift if @_;
   return $self->{REASON};
 }
 
-sub Duration
-{
+sub Duration {
   my $self = shift;
   $self->{DURATION} = shift if @_;
   return $self->{DURATION};
 }
 
-sub Start
-{
+sub Start {
   my $self = shift;
   $self->{START} = shift if @_;
   return $self->{START};
 }
 
-sub RetryMaxAge
-{
+sub RetryMaxAge {
   my $self = shift;
   $self->{RETRY_MAX_AGE} = shift if @_;
   return $self->{RETRY_MAX_AGE};

--- a/src/Monitor/perl_lib/ASO/Job.pm
+++ b/src/Monitor/perl_lib/ASO/Job.pm
@@ -42,7 +42,7 @@ our %exit_states =
 	  Active		=> 0,
 	  Ready			=> 0,
 	  Done			=> 1,
-	  DoneWithErrors	=> 0,
+	  DoneWithErrors	=> 1,
 	  Failed		=> 1,
 	  Finishing		=> 0,
 	  Finished		=> 1,
@@ -138,6 +138,8 @@ sub State
     my $oldstate = $self->{STATE};
     $self->{STATE} = $state;
     $self->{TIMESTAMP} = $timestamp || time;
+    print "Job ",$self->{ID}," state changed from $oldstate to $state at ",($timestamp || time),"\n";
+print "Current raw output:\n",$self->RawOutput(),"\n";
     return $oldstate;
   }
   return undef;

--- a/src/Monitor/perl_lib/ASO/Job.pm
+++ b/src/Monitor/perl_lib/ASO/Job.pm
@@ -76,8 +76,7 @@ sub new {
   return $self;
 }
 
-sub AUTOLOAD
-{
+sub AUTOLOAD {
   my $self = shift;
   my $attr = our $AUTOLOAD;
   $attr =~ s/.*:://;
@@ -95,18 +94,14 @@ sub AUTOLOAD
   $self->$parent(@_);
 }
 
-sub DESTROY
-{
+sub DESTROY {
   my $self = shift;
 
   return unless $self->{COPYJOB};
-# unlink $self->{COPYJOB} if -f $self->{COPYJOB};
-# print $self->{ID},": Unlinked ",$self->{COPYJOB},"\n";
   $self = {};
 }
 
-sub Log
-{
+sub Log {
   my $self = shift;
   push @{$self->{LOG}}, join(' ',@_,"\n") if @_;
 
@@ -114,8 +109,7 @@ sub Log
   return join('',@{$self->{LOG}});
 }
 
-sub RawOutput
-{
+sub RawOutput {
   my $self = shift;
   foreach ( @_ )
   {
@@ -127,8 +121,7 @@ sub RawOutput
   return join('',@{$self->{RAW_OUTPUT}});
 }
 
-sub State
-{
+sub State {
   my ($self,$state,$timestamp) = @_;
   return $self->{STATE} unless $state;
   return undef unless $self->{STATE};
@@ -138,15 +131,13 @@ sub State
     my $oldstate = $self->{STATE};
     $self->{STATE} = $state;
     $self->{TIMESTAMP} = $timestamp || time;
-    print "Job ",$self->{ID}," state changed from $oldstate to $state at ",($timestamp || time),"\n";
-print "Current raw output:\n",$self->RawOutput(),"\n";
+    # print "Job ",$self->{ID}," state changed from $oldstate to $state at ",($timestamp || time),"\n";
     return $oldstate;
   }
   return undef;
 }
 
-sub Files
-{
+sub Files {
   my $self = shift;
   return $self->{FILES} unless @_;
   foreach ( @_ ) {
@@ -155,11 +146,9 @@ sub Files
 }
 
 use Data::Dumper;
-sub Dump
-{
+sub Dump {
   my $self = shift;
-  my ($file);
-  $file = $self->{WORKDIR} . '/job-' . $self->{ID} . '.dump';
+  my $file = $self->{WORKDIR} . '/job-' . $self->{ID} . '.dump';
 
   open DUMP, "> $file" or $self->Fatal("Cannot open $file for dump of job");
   print DUMP Dumper($self);
@@ -184,7 +173,6 @@ die "Prepare... to die...?\n";
 			  );
   }
 
-# print "Using temporary file $filename\n";
   $self->{COPYJOB} = $file;
   foreach ( values %{$self->{FILES}} )
   { my $checksum_str=(defined $_->CHECKSUM_TYPE && defined $_->CHECKSUM_VAL)?
@@ -197,78 +185,67 @@ die "Prepare... to die...?\n";
 
 sub ExitStates { return \%ASO::Job::exit_states; }
 
-sub ID
-{
+sub ID {
   my $self = shift;
   $self->{ID} = $self->{ME} = shift if @_;
   return $self->{ID};
 }
 
-sub Service
-{
+sub Service {
   my $self = shift;
   $self->{SERVICE} = shift if @_;
   return $self->{SERVICE};
 }
 
-sub Timeout
-{
+sub Timeout {
   my $self = shift;
   $self->{TIMEOUT} = shift if @_;
   return $self->{TIMEOUT};
 }
 
-sub FileTimeout
-{
+sub FileTimeout {
   my $self = shift;
   $self->{FILE_TIMEOUT} = shift if @_;
   return $self->{FILE_TIMEOUT};
 }
 
-sub Priority
-{
+sub Priority {
   my $self = shift;
   $self->{PRIORITY} = shift if @_;
   return $self->{PRIORITY};
 }
 
-sub Copyjob
-{
+sub Copyjob {
   my $self = shift;
   $self->{COPYJOB} = shift if @_;
   return $self->{COPYJOB};
 }
 
-sub Workdir
-{
+sub Workdir {
   my $self = shift;
   $self->{WORKDIR} = shift if @_;
   return $self->{WORKDIR};
 }
 
-sub Summary
-{
+sub Summary {
   my $self = shift;
   $self->{SUMMARY} = shift if @_;
   return $self->{SUMMARY};
 }
 
-sub Timestamp
-{
+sub Timestamp {
   my $self = shift;
   $self->{TIMESTAMP} = shift if @_;
   return $self->{TIMESTAMP};
 }
 
-sub FileTimestamp
-{
+sub FileTimestamp {
   my $self = shift;
   $self->{FILE_TIMESTAMP} = shift if @_;
   return $self->{FILE_TIMESTAMP};
 }
 
-sub Tempdir
-{
+sub Tempdir {
   my $self = shift;
   $self->{Tempdir} = shift if @_;
   return $self->{Tempdir};


### PR DESCRIPTION
The issue seems to be with occasional corrupt output from the monitoring command. If this happens for a very short job, which only gets monitored once before it completes, it can cause loss of file-state information. This is now protected, so should not happen again.

So, please test when you can. Please also make sure that job_logs is set in the config file. By default this will now only log jobs that have corrupt output, so it won't fill the disk and it might give some clue as to why this happens.