### PR TITLE
Separate clean function from readToPublishFiles. Rename readToPulishFiles to getPublDescFiles. Add many log messages. Add workflow name to log messages when available.

### DIFF
--- a/src/python/AsyncStageOut/PublisherWorker.py
+++ b/src/python/AsyncStageOut/PublisherWorker.py
@@ -36,6 +36,7 @@ from AsyncStageOut import getHashLfn
 from AsyncStageOut import getDNFromUserName
 from AsyncStageOut import getCommonLogFormatter
 
+
 class PublisherWorker:
 
     def __init__(self, user, config):
@@ -61,22 +62,20 @@ class PublisherWorker:
         self.logger.debug("Trying to get DN")
         try:
             self.userDN = getDNFromUserName(self.user, self.logger)
-        except Exception, ex:
+        except Exception as ex:
             msg =  "Error retrieving the user DN"
             msg += str(ex)
             msg += str(traceback.format_exc())
             self.logger.error(msg)
             self.init = False
             return
-        defaultDelegation = {
-                                  'logger': self.logger,
-                                  'credServerPath' : \
-                                      self.config.credentialDir,
-                                  # It will be moved to be getfrom couchDB
-                                  'myProxySvr': 'myproxy.cern.ch',
-                                  'min_time_left' : getattr(self.config, 'minTimeLeft', 36000),
-                                  'serverDN' : self.config.serverDN,
-                                  'uisource' : self.uiSetupScript
+        defaultDelegation = {'logger': self.logger,
+                             'credServerPath': self.config.credentialDir,
+                             # It will be moved to be getfrom couchDB
+                             'myProxySvr': 'myproxy.cern.ch',
+                             'min_time_left': getattr(self.config, 'minTimeLeft', 36000),
+                             'serverDN': self.config.serverDN,
+                             'uisource': self.uiSetupScript
                             }
         # If we're just testing publication, we skip the DB connection.
         if os.getenv("TEST_ASO"):
@@ -93,7 +92,7 @@ class PublisherWorker:
 		query = {'key':self.user}
            	try:
                     self.user_cache_area = self.db.loadView('DBSPublisher', 'cache_area', query)['rows']
-		except Exception, ex:
+		except Exception as ex:
                     msg =  "Error getting user cache_area"
                     msg += str(ex)
                     msg += str(traceback.format_exc())
@@ -114,7 +113,7 @@ class PublisherWorker:
                 defaultDelegation['group'] = self.group
                 defaultDelegation['role'] = self.role
                 valid, proxy = getProxy(defaultDelegation, self.logger)
-        except Exception, ex:
+        except Exception as ex:
             msg =  "Error getting the user proxy"
             msg += str(ex)
             msg += str(traceback.format_exc())
@@ -150,8 +149,8 @@ class PublisherWorker:
 
         try:
             self.connection = RequestHandler(config={'timeout': 300, 'connecttimeout' : 300})
-        except Exception, ex:
-            msg =  "Error initializing the connection"
+        except Exception as ex:
+            msg = "Error initializing the connection"
             msg += str(ex)
             msg += str(traceback.format_exc())
             self.logger.debug(msg)
@@ -181,6 +180,7 @@ class PublisherWorker:
         ## Loop over the user workflows.
         for user_wf in active_user_workflows:
             workflow = str(user_wf['key'][3])
+            wfnamemsg = "%s: " % (workflow)
             ## This flag is to force calling the publish method (e.g. because the workflow
             ## status is terminal) even if regular criteria would say not to call it (e.g.
             ## because there was already a publication done recently for this workflow and
@@ -192,18 +192,23 @@ class PublisherWorker:
             try:
                 active_files = self.db.loadView('DBSPublisher', 'publish', query)['rows']
             except Exception, e:
-                self.logger.error('A problem occured to retrieve the list of active files for %s: %s' % (self.user, e))
-                self.logger.info('Publications of %s will be retried next time' % workflow)
+                msg = "A problem occured to retrieve the list of active files for %s: %s" % (self.user, e)
+                self.logger.error(wfnamemsg+msg)
+                msg = "Publications will be retried next time."
+                self.logger.info(wfnamemsg+msg)
                 continue
-            self.logger.info('active files in %s: %s' % (workflow, len(active_files)))
+            msg = "Number of active files: %s." % (len(active_files))
+            self.logger.info(wfnamemsg+msg)
             ## If there are no files to publish, continue with the next workflow.
             if not active_files:
+                msg = "Continuing with next workflow/user in the loop."
+                self.logger.info(wfnamemsg+msg)
                 continue
             ## Get the job endtime, destination site, input dataset and input DBS URL for
             ## the active files in the workflow. Put the destination LFNs in a list of ready
             ## files grouped by output dataset.
-            wf_jobs_endtime = []
             lfn_ready = {}
+            wf_jobs_endtime = []
             pnn, input_dataset, input_dbs_url = "", "", ""
             for active_file in active_files:
                 job_end_time = active_file['value'][5]
@@ -235,14 +240,18 @@ class PublisherWorker:
                 else:
                     orig_filename = left_piece
                 lfn_ready.setdefault(orig_filename, []).append(dest_lfn)
-            self.logger.info("There are %s ready files in %s active files." % (sum(map(len, lfn_ready.values())), user_wf['value']))
+            msg = "There are %s ready files in %s active files." % (sum(map(len, lfn_ready.values())), user_wf['value'])
+            self.logger.info(wfnamemsg+msg)
+            msg = "List of jobs end time (len = %s): %s" % (len(wf_jobs_endtime), wf_jobs_endtime)
+            self.logger.debug(wfnamemsg+msg)
             ## Check if the workflow has expired. If it has, force the publication for the
             ## available ready files and mark the rest of the files as 'publication failed'.
             self.force_failure = False
             self.publication_failure_msg = ""
             if wf_jobs_endtime:
-                self.logger.debug("jobs_endtime of %s: %s" % (workflow, wf_jobs_endtime))
                 wf_jobs_endtime.sort()
+                msg = "Oldest job end time: %s. Now: %s." % (wf_jobs_endtime[0], now)
+                self.logger.debug(wfnamemsg+msg)
                 workflow_duration = (now - wf_jobs_endtime[0])
                 workflow_expiration_time = self.config.workflow_expiration_time * 24*60*60
                 if workflow_duration > workflow_expiration_time:
@@ -255,10 +264,11 @@ class PublisherWorker:
                     self.publication_failure_msg = "Workflow %s expired since %sh:%sm:%ss!" % (workflow, hours, minutes, seconds)
                     msg = self.publication_failure_msg
                     msg += " Will force the publication if possible or fail it otherwise."
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
             ## List with the number of ready files per dataset.
             lens_lfn_ready = map(lambda x: len(x), lfn_ready.values())
-            self.logger.info("Number of ready files per dataset: %s" % (lens_lfn_ready))
+            msg = "Number of ready files per dataset: %s." % (lens_lfn_ready)
+            self.logger.info(wfnamemsg+msg)
             ## List with booleans that tell if there are more than max_files_per_block to
             ## publish per dataset.
             enough_lfn_ready = map(lambda x: x >= self.max_files_per_block, lens_lfn_ready)
@@ -271,49 +281,58 @@ class PublisherWorker:
                 ## in which case I would remove the 'if enough_lfn_ready_in_all_datasets' and
                 ## always retrieve the workflow status as seems to me it is cleaner and makes
                 ## the code easier to understand. (Comment from Andres Tanasijczuk)
-                msg  = "All datasets in workflow have more than %s ready files." % (self.max_files_per_block)
-                msg += " No need to retrieve the workflow status nor the last publication time."
-                self.logger.info(msg)
+                msg  = "All datasets have more than %s ready files." % (self.max_files_per_block)
+                msg += " No need to retrieve task status nor last publication time."
+                self.logger.info(wfnamemsg+msg)
             else:
                 msg  = "At least one dataset has less than %s ready files." % (self.max_files_per_block)
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 ## Retrieve the workflow status. If the status can not be retrieved, continue
                 ## with the next workflow.
                 workflow_status = ''
                 url = '/'.join(self.cache_area.split('/')[:-1]) + '/workflow'
-                self.logger.info("Starting retrieving the status of %s from %s" % (workflow, url))
+                msg = "Retrieving status from %s" % (url)
+                self.logger.info(wfnamemsg+msg)
                 buf = cStringIO.StringIO()
                 data = {'workflow': workflow}
                 header = {"Content-Type ":"application/json"}
                 try:
                     response, res_ = self.connection.request(url, data, header, doseq=True, ckey=self.userProxy, cert=self.userProxy)#, verbose=True)# for debug
                 except Exception as ex:
-                    msg = "Error reading the status of %s from cache." % (workflow)
+                    msg  = "Error retrieving status from cache."
                     msg += str(ex)
                     msg += str(traceback.format_exc())
-                    self.logger.error(msg)
+                    self.logger.error(wfnamemsg+msg)
                 else:
-                    self.logger.info("Status of %s read from cache..." % (workflow))
+                    msg = "Status retrieved from cache. Loading task status."
+                    self.logger.info(wfnamemsg+msg)
                     try:
                         buf.close()
                         res = json.loads(res_)
                         workflow_status = res['result'][0]['status']
-                        self.logger.info("Workflow status is %s" % (workflow_status))
+                        msg = "Task status is %s." % (workflow_status)
+                        self.logger.info(wfnamemsg+msg)
                     except ValueError:
-                        self.logger.error("Workflow %s is removed from WM" % (workflow))
+                        msg = "Workflow removed from WM."
+                        self.logger.error(wfnamemsg+msg)
                         workflow_status = 'REMOVED'
                     except Exception as ex:
-                        msg = "Error loading the status of %s !" % (workflow)
+                        msg  = "Error loading task status!"
                         msg += str(ex)
                         msg += str(traceback.format_exc())
-                        self.logger.error(msg)
+                        self.logger.error(wfnamemsg+msg)
                 ## If the workflow status is terminal, go ahead and publish all the ready files
                 ## in the workflow.
                 if workflow_status in ['COMPLETED', 'FAILED', 'KILLED', 'REMOVED']:
                     self.force_publication = True
-                    self.logger.info("Closing publication of workflow %s since its status is considered terminal." % (workflow))
+                    msg = "Considering task status as terminal. Will force publication."
+                    self.logger.info(wfnamemsg+msg)
                 ## Otherwise...
                 else:
+                    msg = "Task status is not considered terminal."
+                    self.logger.info(wfnamemsg+msg)
+                    msg = "Getting last publication time."
+                    self.logger.info(wfnamemsg+msg)
                     ## Get when was the last time a publication was done for this workflow (this
                     ## should be more or less independent of the output dataset in case there are
                     ## more than one).
@@ -321,17 +340,21 @@ class PublisherWorker:
                     try:
                         last_publication_time = self.db.loadView('DBSPublisher', 'last_publication', query)['rows']
                     except Exception as ex:
-                        self.logger.error("Cannot get last publication time from Couch for %s: %s" % (user_wf['key'], ex))
+                        msg = "Cannot get last publication time for %s: %s" % (user_wf['key'], ex)
+                        self.logger.error(wfnamemsg+msg)
                     else:
-                        self.logger.debug("last_publication_time of %s: %s" % (workflow, last_publication_time))
+                        msg = "Last publication time: %s." % (last_publication_time)
+                        self.logger.debug(wfnamemsg+msg)
                         ## If this is the first time a publication would be done for this workflow, go
                         ## ahead and publish.
                         if not last_publication_time:
                             self.force_publication = True
-                            self.logger.info("Will force publication, since there was no previous publication for this workflow.")
+                            msg = "There was no previous publication. Will force publication."
+                            self.logger.info(wfnamemsg+msg)
                         ## Otherwise...
                         else:
-                            self.logger.debug("Last published block: %s" % (last_publication_time[0]['value']['max']))
+                            msg = "Last published block: %s" % (last_publication_time[0]['value']['max'])
+                            self.logger.debug(wfnamemsg+msg)
                             ## If the last publication was long time ago (> our block publication timeout),
                             ## go ahead and publish.
                             time_since_last_publication = now - last_publication_time[0]['value']['max']
@@ -339,81 +362,87 @@ class PublisherWorker:
                             minutes = int((time_since_last_publication - hours*60*60)/60)
                             timeout_hours = int(self.block_publication_timeout/60/60)
                             timeout_minutes = int((self.block_publication_timeout - timeout_hours*60*60)/60)
-                            msg = "Last publication for this workflow was %sh:%sm ago" % (hours, minutes)
+                            msg = "Last publication was %sh:%sm ago" % (hours, minutes)
                             if time_since_last_publication > self.block_publication_timeout:
                                 self.force_publication = True
                                 msg += " (more than the timeout of %sh:%sm)." % (timeout_hours, timeout_minutes)
-                                msg += " Will force new publication."
+                                msg += " Will force publication."
                             else:
                                 msg += " (less than the timeout of %sh:%sm)." % (timeout_hours, timeout_minutes)
-                                msg += " Not enough to force new publication."
-                            self.logger.info(msg)
+                                msg += " Not enough to force publication."
+                            self.logger.info(wfnamemsg+msg)
             ## Call the publish method with the lists of ready files to publish for this
             ## workflow grouped by datasets.
             result = self.publish(workflow, input_dataset, input_dbs_url, pnn, lfn_ready)
             for dataset in result.keys():
                 published_files = result[dataset].get('published', [])
                 if published_files:
-                    self.mark_good(published_files)
+                    self.mark_good(workflow, published_files)
                 failed_files = result[dataset].get('failed', [])
                 if failed_files:
                     failure_reason = result[dataset].get('failure_reason', "")
                     force_failure = result[dataset].get('force_failure', False)
-                    self.mark_failed(failed_files, failure_reason, force_failure)
+                    self.mark_failed(workflow, failed_files, failure_reason, force_failure)
 
         self.logger.info("Publications for user %s (group: %s, role: %s) completed." % (self.user, self.group, self.role))
 
 
-    def mark_good(self, files=[]):
+    def mark_good(self, workflow, files=[]):
         """
         Mark the list of files as tranferred
         """
+        wfnamemsg = "%s: " % (workflow)
         last_update = int(time.time())
         for lfn in files:
+            data = {}
+            source_lfn = self.lfn_map[lfn]
+            docId = getHashLfn(source_lfn)
+            msg  = "Marking file %s as published." % (lfn)
+            msg += " Document id: %s (source LFN: %s)." % (docId, source_lfn)
+            self.logger.info(wfnamemsg+msg)
+            data['publication_state'] = 'published'
+            data['last_update'] = last_update
             try:
-                data = {}
-                data['publication_state'] = 'published'
-                data['last_update'] = last_update
-                lfn_db = self.lfn_map[lfn]
-                updateUri = "/" + self.db.name + "/_design/DBSPublisher/_update/updateFile/" + \
-                            getHashLfn(lfn_db)
+                updateUri = "/" + self.db.name + "/_design/DBSPublisher/_update/updateFile/" + getHashLfn(source_lfn)
                 updateUri += "?" + urllib.urlencode(data)
-                self.logger.info(updateUri)
+                self.logger.info(wfnamemsg+"URI: %s" % updateUri)
                 self.db.makeRequest(uri = updateUri, type = "PUT", decode = False)
             except Exception, ex:
-                msg =  "Error updating document in couch"
+                msg  = "Error updating document in Couch."
                 msg += str(ex)
                 msg += str(traceback.format_exc())
-                self.logger.error(msg)
+                self.logger.error(wfnamemsg+msg)
         try:
             self.db.commit()
         except Exception, ex:
-            msg =  "Error commiting documents in couch"
+            msg  = "Error committing documents in Couch."
             msg += str(ex)
             msg += str(traceback.format_exc())
-            self.logger.error(msg)
+            self.logger.error(wfnamemsg+msg)
 
 
-    def mark_failed( self, files=[], failure_reason="", force_failure=False ):
+    def mark_failed(self, workflow, files=[], failure_reason="", force_failure=False):
         """
         Something failed for these files so increment the retry count
         """
+        wfnamemsg = "%s: " % (workflow)
         now = str(datetime.datetime.now())
         last_update = int(time.time())
         for lfn in files:
-            self.logger.info("Marking failed %s" % lfn)
             data = {}
-            lfn_db = self.lfn_map[lfn]
-            docId = getHashLfn(lfn_db)
-            self.logger.info("Marking failed %s of %s" % (docId, lfn_db))
+            source_lfn = self.lfn_map[lfn]
+            docId = getHashLfn(source_lfn)
+            msg  = "Marking file %s as failed." % (lfn)
+            msg += " Document id: %s (source LFN: %s)." % (docId, source_lfn)
+            self.logger.info(wfnamemsg+msg)
             # Load document to get the retry_count
             try:
-                document = self.db.document( docId )
+                document = self.db.document(docId)
             except Exception, ex:
-                msg =  "Error loading document from couch"
+                msg  = "Error loading document from Couch."
                 msg += str(ex)
                 msg += str(traceback.format_exc())
-                self.logger.error(msg)
+                self.logger.error(wfnamemsg+msg)
                 continue
             # Prepare data to update the document in couch
             if len(document['publication_retry_count']) + 1 > self.max_retry or force_failure:
@@ -423,25 +452,24 @@ class PublisherWorker:
             data['last_update'] = last_update
             data['retry'] = now
             data['publication_failure_reason'] = failure_reason
-
             # Update the document in couch
             try:
                 updateUri = "/" + self.db.name + "/_design/DBSPublisher/_update/updateFile/" + docId
                 updateUri += "?" + urllib.urlencode(data)
-                self.logger.info(updateUri)
+                self.logger.info(wfnamemsg+"URI: %s" % updateUri)
                 self.db.makeRequest(uri = updateUri, type = "PUT", decode = False)
             except Exception, ex:
-                msg =  "Error in updating document in couch"
+                msg  = "Error updating document in Couch."
                 msg += str(ex)
                 msg += str(traceback.format_exc())
-                self.logger.error(msg)
+                self.logger.error(wfnamemsg+msg)
         try:
             self.db.commit()
         except Exception, ex:
-            msg =  "Error commiting documents in couch"
+            msg  = "Error committing documents in Couch."
             msg += str(ex)
             msg += str(traceback.format_exc())
-            self.logger.error(msg)
+            self.logger.error(wfnamemsg+msg)
 
 
     def publish(self, workflow, inputDataset, sourceURL, pnn, lfn_ready):
@@ -452,28 +480,52 @@ class PublisherWorker:
            :arg str pnn
            :arg dict lfn_ready
            :return: the publication status or result"""
+        wfnamemsg = "%s: " % (workflow)
         retdict = {}
         ## Don't publish anything if there are not enough ready files to make a block in
         ## any of the datasets and publication was not forced. This is a first filtering
         ## so to not retrieve the filemetadata unnecesarily.
         if not False in map(lambda x: len(x) < self.max_files_per_block, lfn_ready.values()) and not self.force_publication:
+            msg = "Skipping publication as there are not enough ready files in any of the datasets (and publication was not forced)."
+            self.logger.info(wfnamemsg+msg) 
             return retdict
-        ## Get the filemetada for all the ready files in the workflow.
+        ## Get the filemetada for this workflow.
+        msg = "Retrieving publication description files."
+        self.logger.info(wfnamemsg+msg)
         lfn_ready_list = []
         for v in lfn_ready.values():
             lfn_ready_list.extend(v)
-        toPublish = {}
         try:
-            toPublish = self.readToPublishFiles(workflow, self.user, lfn_ready_list)
+            publDescFiles_list = self.getPublDescFiles(workflow, self.user)
         except (tarfile.ReadError, RuntimeError):
-            msg = "Unable to read publication description files."
-            self.logger.error(msg)
+            msg = "Error retrieving publication description files."
+            self.logger.error(wfnamemsg+msg)
             retdict = {'unknown_datasets': {'failed': lfn_ready_list, 'failure_reason': msg, 'force_failure': False, 'published': []}}
             return retdict
+        msg = "Number of publication description files: %s" % (len(publDescFiles_list))
+        self.logger.info(wfnamemsg+msg)
+        ## Group the filemetadata according to the output dataset.
+        msg = "Grouping publication description files according to output dataset."
+        self.logger.info(wfnamemsg+msg)
+        publDescFiles = {}
+        for publDescFile in publDescFiles_list:
+            dataset = str(publDescFile['outdataset'])
+            publDescFiles.setdefault(dataset, []).append(publDescFile)
+        msg = "Publication description files: %s" % (publDescFiles)
+        self.logger.debug(wfnamemsg+msg)
+        ## Discard ready files for which there is no filemetadata.
+        msg = "Discarding ready files for which there is no publication description file available (and vice versa)."
+        self.logger.info(wfnamemsg+msg)
+        toPublish = self.clean(lfn_ready_list, publDescFiles)
+        msg = "Number of publication description files to publish: %s" % (sum(map(lambda x: len(x), toPublish.values())))
+        self.logger.info(wfnamemsg+msg)
+        msg = "Publication description files to publish: %s" % (toPublish)
+        self.logger.debug(wfnamemsg+msg)
+        ## If there is nothing to publish, return.
         if not toPublish:
             if self.force_failure:
-                msg = "Outputs filemetadata not found in cache! Forcing publication failure."
-                self.logger.error(msg)
+                msg = "Publication description files not found! Will force publication failure."
+                self.logger.error(wfnamemsg+msg)
                 if self.publication_failure_msg:
                     msg += " %s" % (self.publication_failure_msg)
                 retdict = {'unknown_datasets': {'failed': lfn_ready_list, 'failure_reason': msg, 'force_failure': True, 'published': []}}
@@ -483,25 +535,34 @@ class PublisherWorker:
         for dataset in toPublish.keys():
             files = toPublish[dataset]
             if len(files) < self.max_files_per_block and not self.force_publication:
+                msg  = "There are only %s (less than %s) files to publish in dataset %s." % (len(files), self.max_files_per_block, dataset)
+                msg += " Will skip publication in this dataset (publication was not forced)."
+                self.logger.info(wfnamemsg+msg)
                 toPublish.pop(dataset)
         ## Finally... publish if there is something left to publish.
         if not toPublish:
+            msg = "Nothing to publish."
+            self.logger.info(wfnamemsg+msg)
             return retdict
         for dataset in toPublish.keys():
-            self.logger.info('toPublish %s files in %s' % (len(toPublish[dataset]), dataset))
-        self.logger.info("Starting data publication in DBS of %s" % str(workflow))
-        failed, failure_reason, published, dbsResults = self.publishInDBS3(sourceURL, inputDataset, toPublish, pnn)
-        self.logger.debug("DBS publication results %s" % (dbsResults))
+            msg = "Will publish %s files in dataset %s." % (len(toPublish[dataset]), dataset)
+            self.logger.info(wfnamemsg+msg)
+        msg = "Starting publication in DBS."
+        self.logger.info(wfnamemsg+msg)
+        failed, failure_reason, published, dbsResults = self.publishInDBS3(workflow, sourceURL, inputDataset, toPublish, pnn)
+        msg = "DBS publication results: %s" % (dbsResults)
+        self.logger.debug(wfnamemsg+msg)
         for dataset in toPublish.keys():
             retdict.update({dataset: {'failed': failed.get(dataset, []), 'failure_reason': failure_reason.get(dataset, ""), 'published': published.get(dataset, [])}})
         return retdict
 
 
-    def readToPublishFiles(self, workflow, userhn, lfn_ready):
+    def getPublDescFiles(self, workflow, userhn):
         """
         Download and read the files describing
         what needs to be published
         """
+        wfnamemsg = "%s: " % (workflow)
         def decodeAsString(a):
             """
             DBS is stupid and doesn't understand that unicode is a string: (if type(obj) == type(''))
@@ -516,54 +577,47 @@ class PublisherWorker:
                     value = str(value)
                 newDict.update({key : value})
             return newDict
-        self.logger.info("Starting Read cache for %s..." % workflow)
         buf = cStringIO.StringIO()
         res = []
         # TODO: input sanitization
-        header = {"Content-Type ":"application/json"}
+        header = {"Content-Type ": "application/json"}
         data = {'taskname': workflow, 'filetype': 'EDM'}
         url = self.cache_area
+        msg = "Retrieving data from %s" % (url)
+        self.logger.info(wfnamemsg+msg)
         try:
             response, res_ = self.connection.request(url, data, header, doseq=True, ckey=self.userProxy, cert=self.userProxy)#, verbose=True)# for debug
         except Exception, ex:
-            msg =  "Error reading data from cache"
+            msg  = "Error retrieving data."
             msg += str(ex)
             msg += str(traceback.format_exc())
-            self.logger.error(msg)
+            self.logger.error(wfnamemsg+msg)
             return {}
-        self.logger.info("Data read from cache...")
+        msg = "Loading results."
+        self.logger.info(wfnamemsg+msg)
         try:
             buf.close()
             res = json.loads(res_)
         except Exception, ex:
-            msg =  "Error loading results. Trying next time!"
+            msg  = "Error loading results. Trying next time!"
             msg += str(ex)
             msg += str(traceback.format_exc())
-            self.logger.error(msg)
+            self.logger.error(wfnamemsg+msg)
             return {}
-        self.logger.info("%s records got from cache" % len(res['result']))
-        self.logger.debug("results %s..." % res['result'])
-        toPublish = {}
-        for filemetadata in res['result']:
-            dataset = str(filemetadata['outdataset'])
-            toPublish.setdefault(dataset, []).append(filemetadata)
-        toPublish = self.clean(lfn_ready, toPublish)
-        self.logger.debug('toPublish = %s' % toPublish)
-        return toPublish
+        return res['result']
 
 
-    def clean(self, lfn_ready, toPublish):
+    def clean(self, lfn_ready_list, publDescFiles):
         """
-        Clean before publishing
+        Discard ready files that have no filematadata (and vice versa).
         """
-        new_toPublish = {}
-        for dataset, outfiles_metadata in toPublish.iteritems():
+        publDescFiles_filtered = {}
+        for dataset, outfiles_metadata in publDescFiles.iteritems():
             for outfile_metadata in outfiles_metadata:
                 dest_lfn = outfile_metadata['lfn']
-                if dest_lfn in lfn_ready:
-                    new_toPublish.setdefault(dataset, []).append(outfile_metadata)
-        self.logger.info('Cleaning ends')
-        return new_toPublish
+                if dest_lfn in lfn_ready_list:
+                    publDescFiles_filtered.setdefault(dataset, []).append(outfile_metadata)
+        return publDescFiles_filtered
 
 
     def format_file_3(self, file):
@@ -585,7 +639,7 @@ class PublisherWorker:
         return nf
 
 
-    def migrateByBlockDBS3(self, migrateApi, destReadApi, sourceApi, inputDataset, inputBlocks = None):
+    def migrateByBlockDBS3(self, workflow, migrateApi, destReadApi, sourceApi, inputDataset, inputBlocks = None):
         """
         Submit one migration request for each block that needs to be migrated.
         If inputBlocks is missing, migrate the full dataset.
@@ -593,6 +647,7 @@ class PublisherWorker:
                    if all migrations have finished ok,
                  - an empty list otherwise.
         """
+        wfnamemsg = "%s: " % (workflow)
         if inputBlocks:
             blocksToMigrate = set(inputBlocks)
         else:
@@ -604,24 +659,24 @@ class PublisherWorker:
             blocksToMigrate = blocksInSourceDBS - blocksInDestDBS
             msg = "Dataset %s in destination DBS with %d blocks; %d blocks in source DBS."
             msg = msg % (inputDataset, len(blocksInDestDBS), len(blocksInSourceDBS))
-            self.logger.info(msg)
+            self.logger.info(wfnamemsg+msg)
         numBlocksToMigrate = len(blocksToMigrate)
         if numBlocksToMigrate == 0:
-            self.logger.info("No migration needed.")
+            self.logger.info(wfnamemsg+"No migration needed.")
         else:
             msg = "Have to migrate %d blocks from %s to %s." % (numBlocksToMigrate, sourceApi.url, destReadApi.url)
-            self.logger.info(msg)
+            self.logger.info(wfnamemsg+msg)
             msg = "List of blocks to migrate:\n%s." % (", ".join(blocksToMigrate))
-            self.logger.debug(msg)
+            self.logger.debug(wfnamemsg+msg)
             msg = "Submitting %d block migration requests to DBS3 ..." % (numBlocksToMigrate)
-            self.logger.info(msg)
+            self.logger.info(wfnamemsg+msg)
             numBlocksAtDestination = 0
             numQueuedUnkwonIds = 0
             numFailedSubmissions = 0
             migrationIdsInProgress = []
             for block in list(blocksToMigrate):
                 ## Submit migration request for this block.
-                (reqid, atDestination, alreadyQueued) = self.requestBlockMigration(migrateApi, sourceApi, block)
+                (reqid, atDestination, alreadyQueued) = self.requestBlockMigration(workflow, migrateApi, sourceApi, block)
                 ## If the block is already in the destination DBS instance, we don't need
                 ## to monitor its migration status. If the migration request failed to be
                 ## submitted, we retry it next time. Otherwise, save the migration request
@@ -638,24 +693,24 @@ class PublisherWorker:
                     migrationIdsInProgress.append(reqid)
             if numBlocksAtDestination > 0:
                 msg = "%d blocks already in destination DBS." % (numBlocksAtDestination)
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
             if numFailedSubmissions > 0:
                 msg  = "%d block migration requests failed to be submitted." % (numFailedSubmissions)
                 msg += " Will retry them later."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
             if numQueuedUnkwonIds > 0:
                 msg  = "%d block migration requests were already queued," % (numQueuedUnkwonIds)
                 msg += " but could not retrieve their request id."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
             numMigrationsInProgress = len(migrationIdsInProgress)
             if numMigrationsInProgress == 0:
                 msg = "No migrations in progress."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
             else:
                 msg = "%d block migration requests successfully submitted." % (numMigrationsInProgress)
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 msg = "List of migration requests ids: %s" % (migrationIdsInProgress)
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 ## Wait for up to 300 seconds, then return to the main loop. Note that we
                 ## don't fail or cancel any migration request, but just retry it next time.
                 ## Migration states:
@@ -671,11 +726,11 @@ class PublisherWorker:
                 waitTime = 30
                 numTimes = 10
                 msg = "Will monitor their status for up to %d seconds." % (waitTime * numTimes)
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 for i in range(numTimes):
                     msg  = "%d block migrations in progress." % (numMigrationsInProgress)
                     msg += " Will check migrations status in %d seconds." % (waitTime)
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
                     time.sleep(waitTime)
                     ## Check the migration status of each block migration request.
                     ## If a block migration has succeeded or terminally failes, remove the
@@ -687,29 +742,29 @@ class PublisherWorker:
                             retry = status[0].get('retry_count')
                         except Exception, ex:
                             msg = "Could not get status for migration id %d:\n%s" % (reqid, ex.msg)
-                            self.logger.error(msg)
+                            self.logger.error(wfnamemsg+msg)
                         else:
                             if state == 2:
                                 msg = "Migration id %d succeeded." % (reqid)
-                                self.logger.info(msg)
+                                self.logger.info(wfnamemsg+msg)
                                 migrationIdsInProgress.remove(reqid)
                                 numSuccessfulMigrations += 1
                             if state == 9:
                                 msg = "Migration id %d terminally failed." % (reqid)
-                                self.logger.info(msg)
+                                self.logger.info(wfnamemsg+msg)
                                 msg = "Full status for migration id %d:\n%s" % (reqid, str(status))
-                                self.logger.debug(msg)
+                                self.logger.debug(wfnamemsg+msg)
                                 migrationIdsInProgress.remove(reqid)
                                 numFailedMigrations += 1
                             if state == 3:
                                 if retry < 3:
                                     msg = "Migration id %d failed (retry %d), but should be retried." % (reqid, retry)
-                                    self.logger.info(msg)
+                                    self.logger.info(wfnamemsg+msg)
                                 else:
                                     msg = "Migration id %d failed (retry %d)." % (reqid, retry)
-                                    self.logger.info(msg)
+                                    self.logger.info(wfnamemsg+msg)
                                     msg = "Full status for migration id %d:\n%s" % (reqid, str(status))
-                                    self.logger.debug(msg)
+                                    self.logger.debug(wfnamemsg+msg)
                                     migrationIdsInProgress.remove(reqid)
                                     numFailedMigrations += 1
                     numMigrationsInProgress = len(migrationIdsInProgress)
@@ -721,44 +776,45 @@ class PublisherWorker:
                 ## "migration has failed or is not complete").
                 if numMigrationsInProgress > 0:
                     msg = "Migration of %s has taken too long - will delay the publication." % (inputDataset)
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
                     return []
             msg = "Migration of %s has finished." % (inputDataset)
-            self.logger.info(msg)
+            self.logger.info(wfnamemsg+msg)
             msg  = "Migration status summary (from %d input blocks to migrate):" % (numBlocksToMigrate)
             msg += " at destination = %d," % (numBlocksAtDestination)
             msg += " succeeded = %d," % (numSuccessfulMigrations)
             msg += " failed = %d," % (numFailedMigrations)
             msg += " submission failed = %d," % (numFailedSubmissions)
             msg += " queued with unknown id = %d." % (numQueuedUnkwonIds)
-            self.logger.info(msg)
+            self.logger.info(wfnamemsg+msg)
             ## If there were failed migrations, return an empty list (the caller
             ## function should interpret this as "migration has failed or is not
             ## complete").
             if numFailedMigrations > 0 or numFailedSubmissions > 0:
                 msg = "Some blocks failed to be migrated."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 return []
             if numQueuedUnkwonIds > 0:
                 msg = "Some block migrations were already queued, but failed to retrieve the request id."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 return []
             if (numBlocksAtDestination + numSuccessfulMigrations) == numBlocksToMigrate:
                 msg = "Migration was successful."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
         existingDatasets = destReadApi.listDatasets(dataset = inputDataset, detail = True, dataset_access_type = '*')
         return existingDatasets
 
 
-    def requestBlockMigration(self, migrateApi, sourceApi, block):
+    def requestBlockMigration(self, workflow, migrateApi, sourceApi, block):
         """
         Submit migration request for one block, checking the request output.
         """
+        wfnamemsg = "%s: " % (workflow)
         atDestination = False
         alreadyQueued = False
         reqid = None
         msg = "Submiting migration request for block %s ..." % (block)
-        self.logger.info(msg)
+        self.logger.info(wfnamemsg+msg)
         sourceURL = sourceApi.url
         data = {'migration_url': sourceURL, 'migration_input': block}
         try:
@@ -766,22 +822,22 @@ class PublisherWorker:
         except HTTPError, he:
             if "is already at destination" in he.msg:
                 msg = "Block is already at destination."
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 atDestination = True
             else:
                 msg  = "Request to migrate %s failed." % (block)
                 msg += "\nRequest detail: %s" % (data)
                 msg += "\nDBS3 exception: %s" % (he.msg)
-                self.logger.error(msg)
+                self.logger.error(wfnamemsg+msg)
         if not atDestination:
             msg = "Result of migration request: %s" % (str(result))
-            self.logger.debug(msg)
+            self.logger.debug(wfnamemsg+msg)
             reqid = result.get('migration_details', {}).get('migration_request_id')
             report = result.get('migration_report')
             if reqid == None:
                 msg  = "Migration request failed to submit."
                 msg += "\nMigration request results: %s" % (str(result))
-                self.logger.error(msg)
+                self.logger.error(wfnamemsg+msg)
             if "REQUEST ALREADY QUEUED" in report:
                 ## Request could be queued in another thread, then there would be
                 ## no id here, so look by block and use the id of the queued request.
@@ -791,7 +847,7 @@ class PublisherWorker:
                     reqid = status[0].get('migration_request_id')
                 except Exception:
                     msg = "Could not get status for already queued migration of block %s." % (block)
-                    self.logger.error(msg)
+                    self.logger.error(wfnamemsg+msg)
         return (reqid, atDestination, alreadyQueued)
 
 
@@ -823,10 +879,11 @@ class PublisherWorker:
         return blockDump
 
 
-    def publishInDBS3(self, sourceURL, inputDataset, toPublish, pnn):
+    def publishInDBS3(self, workflow, sourceURL, inputDataset, toPublish, pnn):
         """
         Publish files into DBS3
         """
+        wfnamemsg = "%s: " % (workflow)
         published = {}
         failed = {}
         publish_in_next_iteration = {}
@@ -851,15 +908,15 @@ class PublisherWorker:
         globalURL = globalURL.replace('caf', 'global')
 
         proxy = os.environ.get("SOCKS5_PROXY")
-        self.logger.debug("Source API URL: %s" % sourceURL)
+        self.logger.debug(wfnamemsg+"Source API URL: %s" % sourceURL)
         sourceApi = dbsClient.DbsApi(url=sourceURL, proxy=proxy)
-        self.logger.debug("Global API URL: %s" % globalURL)
+        self.logger.debug(wfnamemsg+"Global API URL: %s" % globalURL)
         globalApi = dbsClient.DbsApi(url=globalURL, proxy=proxy)
-        self.logger.debug("Destination API URL: %s" % self.publish_dbs_url)
+        self.logger.debug(wfnamemsg+"Destination API URL: %s" % self.publish_dbs_url)
         destApi = dbsClient.DbsApi(url=self.publish_dbs_url, proxy=proxy)
-        self.logger.debug("Destination read API URL: %s" % self.publish_read_url)
+        self.logger.debug(wfnamemsg+"Destination read API URL: %s" % self.publish_read_url)
         destReadApi = dbsClient.DbsApi(url=self.publish_read_url, proxy=proxy)
-        self.logger.debug("Migration API URL: %s" % self.publish_migrate_url)
+        self.logger.debug(wfnamemsg+"Migration API URL: %s" % self.publish_migrate_url)
         migrateApi = dbsClient.DbsApi(url=self.publish_migrate_url, proxy=proxy)
 
         if not noInput:
@@ -869,12 +926,14 @@ class PublisherWorker:
             # CRAB2 uses 'crab2_tag' for all cases
             existing_output = destReadApi.listOutputConfigs(dataset=inputDataset)
             if not existing_output:
-                self.logger.error("Unable to list output config for input dataset %s." % inputDataset)
+                msg = "Unable to list output config for input dataset %s." % (inputDataset)
+                self.logger.error(wfnamemsg+msg)
                 global_tag = 'crab3_tag'
             else:
                 global_tag = existing_output[0]['global_tag']
         else:
-            self.logger.info("This publication appears to be for private MC.")
+            msg = "This publication appears to be for private MC."
+            self.logger.info(wfnamemsg+msg)
             primary_ds_type = 'mc'
             global_tag = 'crab3_tag'
 
@@ -882,7 +941,8 @@ class PublisherWorker:
         processing_era_config = {'processing_version': 1, 'description': 'CRAB3_processing_era'}
 
         ## Loop over the datasets to publish.
-        self.logger.debug("Starting iteration through datasets/files for publication.")
+        msg = "Starting iteration through datasets/files for publication."
+        self.logger.debug(wfnamemsg+msg)
         for dataset, files in toPublish.iteritems():
             ## Make sure to add the dataset name as a key in all the dictionaries that will
             ## be returned.
@@ -909,9 +969,11 @@ class PublisherWorker:
             empty, primName, procName, tier = dataset.split('/')
 
             primds_config = {'primary_ds_name': primName, 'primary_ds_type': primary_ds_type}
-            self.logger.debug("About to insert primary dataset: %s" % str(primds_config))
+            msg = "About to insert primary dataset: %s" % (str(primds_config))
+            self.logger.debug(wfnamemsg+msg)
             destApi.insertPrimaryDataset(primds_config)
-            self.logger.debug("Successfully inserted primary dataset %s" % primName)
+            msg = "Successfully inserted primary dataset %s." % (primName)
+            self.logger.debug(wfnamemsg+msg)
 
             ## Find all (valid) files already published in this dataset.
             try:
@@ -920,12 +982,12 @@ class PublisherWorker:
                 existingFilesValid = [f['logical_file_name'] for f in existingDBSFiles if f['is_file_valid']]
                 msg  = "Dataset %s already contains %d files" % (dataset, len(existingFiles))
                 msg += " (%d valid, %d invalid)." % (len(existingFilesValid), len(existingFiles) - len(existingFilesValid))
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 results[dataset]['existingFiles'] = len(existingFiles)
             except Exception, ex:
                 msg  = "Error when listing files in DBS: %s" % (str(ex))
                 msg += "\n%s" % (str(traceback.format_exc()))
-                self.logger.error(msg)
+                self.logger.error(wfnamemsg+msg)
                 continue
 
             ## Is there anything to do?
@@ -939,7 +1001,7 @@ class PublisherWorker:
             ## files in the list of published files and continue with the next dataset.
             if not workToDo:
                 msg = "Nothing uploaded, %s has these files already or not enough files." % (dataset)
-                self.logger.info(msg)
+                self.logger.info(wfnamemsg+msg)
                 published[dataset].extend([f['lfn'] for f in files])
                 continue
 
@@ -951,7 +1013,8 @@ class PublisherWorker:
                              'output_module_label': 'o', #TODO
                              'global_tag': global_tag,
                             }
-            self.logger.debug("Published output config.")
+            msg = "Published output config."
+            self.logger.debug(wfnamemsg+msg)
 
             dataset_config = {'dataset': dataset,
                               'processed_ds_name': procName,
@@ -961,7 +1024,8 @@ class PublisherWorker:
                               'physics_group_name': 'CRAB3',
                               'last_modification_date': int(time.time()),
                              }
-            self.logger.info("About to insert dataset: %s" % str(dataset_config))
+            msg = "About to insert dataset: %s" % (str(dataset_config))
+            self.logger.info(wfnamemsg+msg)
             del dataset_config['acquisition_era_name']
 
             ## List of all files that must (and can) be published.
@@ -1022,7 +1086,7 @@ class PublisherWorker:
                         ## (so that when publishing, this "parent" file will not appear as a parent).
                         if parentFile in parentsToSkip:
                             msg = "Skipping parent file %s, as it doesn't seem to be known to DBS." % (parentFile)
-                            self.logger.info(msg)
+                            self.logger.info(wfnamemsg+msg)
                             if parentFile in file['parents']:
                                 file['parents'].remove(parentFile)
                     ## Add this file to the list of files to be published.
@@ -1030,12 +1094,13 @@ class PublisherWorker:
                 published[dataset].append(file['lfn'])
 
             ## Print a message with the number of files to publish.
-            msg = "Found %d files not already present in DBS which will be published." % len(dbsFiles)
-            self.logger.info(msg)
+            msg = "Found %d files not already present in DBS which will be published." % (len(dbsFiles))
+            self.logger.info(wfnamemsg+msg)
 
             ## If there are no files to publish, continue with the next dataset.
             if len(dbsFiles) == 0:
-                self.logger.info("Nothing to do for this dataset.")
+                msg = "Nothing to do for this dataset."
+                self.logger.info(wfnamemsg+msg)
                 continue
 
             ## Migrate parent blocks before publishing.
@@ -1043,34 +1108,34 @@ class PublisherWorker:
             ## as the input dataset.
             if localParentBlocks:
                 msg = "List of parent blocks that need to be migrated from %s:\n%s" % (sourceApi.url, localParentBlocks)
-                self.logger.info(msg)
-                existingDatasets = self.migrateByBlockDBS3(migrateApi, destReadApi, sourceApi, inputDataset, localParentBlocks)
+                self.logger.info(wfnamemsg+msg)
+                existingDatasets = self.migrateByBlockDBS3(workflow, migrateApi, destReadApi, sourceApi, inputDataset, localParentBlocks)
                 if not existingDatasets:
                     msg = "Failed to migrate %s from %s to %s; not publishing any files." % (inputDataset, sourceApi.url, destReadApi.url)
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
                     failed[dataset].extend([f['logical_file_name'] for f in dbsFiles])
                     failure_reason[dataset] = msg
                     continue
                 if not existingDatasets[0]['dataset'] == inputDataset:
                     msg = "ERROR: Inconsistent state: %s migrated, but listDatasets didn't return any information." % (inputDataset)
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
                     failed[dataset].extend([f['logical_file_name'] for f in dbsFiles])
                     failure_reason[dataset] = msg
                     continue
             ## Then migrate the parent blocks that are in the global DBS instance.
             if globalParentBlocks:
                 msg = "List of parent blocks that need to be migrated from %s:\n%s" % (globalApi.url, globalParentBlocks)
-                self.logger.info(msg)
-                existingDatasets = self.migrateByBlockDBS3(migrateApi, destReadApi, globalApi, inputDataset, globalParentBlocks)
+                self.logger.info(wfnamemsg+msg)
+                existingDatasets = self.migrateByBlockDBS3(workflow, migrateApi, destReadApi, globalApi, inputDataset, globalParentBlocks)
                 if not existingDatasets:
                     msg = "Failed to migrate %s from %s to %s; not publishing any files." % (inputDataset, globalApi.url, destReadApi.url)
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
                     failed[dataset].extend([f['logical_file_name'] for f in dbsFiles])
                     failure_reason[dataset] = msg
                     continue
                 if not existingDatasets[0]['dataset'] == inputDataset:
                     msg = "ERROR: Inconsistent state: %s migrated, but listDatasets didn't return any information" % (inputDataset)
-                    self.logger.info(msg)
+                    self.logger.info(wfnamemsg+msg)
                     failed[dataset].extend([f['logical_file_name'] for f in dbsFiles])
                     failure_reason[dataset] = msg
                     continue
@@ -1086,10 +1151,11 @@ class PublisherWorker:
                 files_to_publish = dbsFiles[count:count+self.max_files_per_block]
                 try:
                     block_config = {'block_name': block_name, 'origin_site_name': pnn, 'open_for_writing': 0}
-                    self.logger.debug("Inserting files %s into block %s." % ([f['logical_file_name'] for f in files_to_publish], block_name))
+                    msg = "Inserting files %s into block %s." % ([f['logical_file_name'] for f in files_to_publish], block_name)
+                    self.logger.debug(wfnamemsg+msg)
                     blockDump = self.createBulkBlock(output_config, processing_era_config, primds_config, dataset_config, \
                                                      acquisition_era_config, block_config, files_to_publish)
-                    #self.logger.debug("Block to insert: %s\n" % pprint.pformat(blockDump))
+                    #self.logger.debug(wfnamemsg+"Block to insert: %s\n" % pprint.pformat(blockDump))
                     destApi.insertBulkBlock(blockDump)
                     block_count += 1
                 except Exception, ex:
@@ -1097,7 +1163,7 @@ class PublisherWorker:
                     msg  = "Error when publishing (%s) " % ", ".join(failed[dataset])
                     msg += str(ex)
                     msg += str(traceback.format_exc())
-                    self.logger.error(msg)
+                    self.logger.error(wfnamemsg+msg)
                     failure_reason[dataset] = str(ex)
                 count += self.max_files_per_block
                 files_to_publish_next = dbsFiles[count:count+self.max_files_per_block]
@@ -1114,5 +1180,5 @@ class PublisherWorker:
             msg += ", published (%s) %s" % (len(published[dataset]), published[dataset])
             msg += ", publish_in_next_iteration (%s) %s" % (len(publish_in_next_iteration[dataset]), publish_in_next_iteration[dataset])
             msg += ", results %s" % (results[dataset])
-            self.logger.info(msg)
+            self.logger.info(wfnamemsg+msg)
         return failed, failure_reason, published, results


### PR DESCRIPTION
Not sure if instead of doing 
```
wfnamemsg = "%s: " % (workflow)
self.logger.info(wfnamemsg+msg)
```
I could instead just set the formatter of the handlers:
```
for h in self.logger.handlers:
    h.setFormatter(logging.Formatter("%(acstime)s:%(level)s:%(module)s:"+workflow+": %(message)s"))
```
