### PR TITLE
Patch for #4237 and #4298

### DIFF
--- a/src/python/AsyncStageOut/BaseDaemon.py
+++ b/src/python/AsyncStageOut/BaseDaemon.py
@@ -1,0 +1,29 @@
+import logging
+
+from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
+
+from AsyncStageOut import getCommonLogFormatter
+
+class BaseDaemon(BaseWorkerThread):
+    """
+    _DaemonBase_
+    Base class for AsyncStageOut daemons.
+    """
+    def __init__(self, config, componentName):
+        BaseWorkerThread.__init__(self)
+        self.config = getattr(config, componentName)
+        self.editLogger()
+        self.logger.debug("Configuration loaded")
+
+    def editLogger(self):
+        #logging.basicConfig(format = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s',datefmt = '%m-%d %H:%M')
+        #self.logger = logging.getLogger()
+        # self.logger is set up by the BaseWorkerThread, we just set it's level
+        try:
+            self.logger.setLevel(self.config.log_level)
+        except:
+            self.logger = logging.getLogger()
+            self.logger.setLevel(self.config.log_level)
+        formatter = getCommonLogFormatter(self.config)
+        for handler in self.logger.handlers:
+            handler.setFormatter(formatter)

--- a/src/python/AsyncStageOut/LFNSourceDuplicator.py
+++ b/src/python/AsyncStageOut/LFNSourceDuplicator.py
@@ -4,11 +4,12 @@
 _LFNSourceDuplicator_
 Duplicate view in Async. database
 """
-from WMCore.Database.CMSCouch                 import CouchServer
-from WMCore.WorkerThreads.BaseWorkerThread    import BaseWorkerThread
 from WMCore.WMFactory import WMFactory
+from WMCore.Database.CMSCouch import CouchServer
 
-class LFNSourceDuplicator(BaseWorkerThread):
+from AsyncStageOut.BaseDaemon import BaseDaemon
+
+class LFNSourceDuplicator(BaseDaemon):
     """
     _LFNSourceDuplicator_
     Load plugin to get the result of the source database query.
@@ -17,19 +18,7 @@ class LFNSourceDuplicator(BaseWorkerThread):
 
     def __init__(self, config):
 
-        BaseWorkerThread.__init__(self)
-
-        self.config = config.AsyncTransfer
-
-        # self.logger is set up by the BaseWorkerThread, we just set it's level
-        try:
-            self.logger.setLevel(self.config.log_level)
-        except:
-            import logging
-            self.logger = logging.getLogger()
-            self.logger.setLevel(self.config.log_level)
-
-        self.logger.debug('Configuration loaded')
+        BaseDaemon.__init__(self, config, 'AsyncTransfer')
 
         # Set up a factory for loading plugins
         self.factory = WMFactory(self.config.pluginDir, namespace = self.config.pluginDir)

--- a/src/python/AsyncStageOut/PublisherWorker.py
+++ b/src/python/AsyncStageOut/PublisherWorker.py
@@ -9,27 +9,32 @@ The Publisherworker does the following:
 
 There should be one worker per user transfer.
 '''
-import time
-import logging
 import os
+import re
+import json
+import time
+import uuid
+import types
+import pprint
+import urllib
+import tarfile
+import logging
 import datetime
 import traceback
-import tarfile
-import urllib
-import json
-import types
-import re
-import uuid
-import pprint
-from WMCore.Database.CMSCouch import CouchServer
-from AsyncStageOut import getHashLfn
-from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
-from RestClient.ErrorHandling.RestClientExceptions import HTTPError
-import dbs.apis.dbsClient as dbsClient
-from WMCore.Services.pycurl_manager import RequestHandler
 import cStringIO
-from AsyncStageOut import getDNFromUserName
+
+import dbs.apis.dbsClient as dbsClient
+
+from RestClient.ErrorHandling.RestClientExceptions import HTTPError
+
+from WMCore.Database.CMSCouch import CouchServer
+from WMCore.Services.PhEDEx.PhEDEx import PhEDEx
+from WMCore.Services.pycurl_manager import RequestHandler
+
 from AsyncStageOut import getProxy
+from AsyncStageOut import getHashLfn
+from AsyncStageOut import getDNFromUserName
+from AsyncStageOut import getCommonLogFormatter
 
 class PublisherWorker:
 
@@ -43,6 +48,9 @@ class PublisherWorker:
         self.config = config
         logging.basicConfig(level=config.log_level)
         self.logger = logging.getLogger('DBSPublisher-Worker-%s' % self.user)
+        formatter = getCommonLogFormatter(self.config)
+        for handler in logging.getLogger().handlers:
+            handler.setFormatter(formatter)
         self.pfn_to_lfn_mapping = {}
         self.max_retry = config.publication_max_retry
         self.uiSetupScript = getattr(self.config, 'UISetupScript', None)

--- a/src/python/AsyncStageOut/ReporterWorker.py
+++ b/src/python/AsyncStageOut/ReporterWorker.py
@@ -11,20 +11,22 @@ There should be one worker per user transfer.
 
 
 '''
-from WMCore.Database.CMSCouch import CouchServer
-
-import time
-import logging
 import os
+import re
+import json
+import time
+import urllib
+import logging
 import datetime
 import traceback
+
 from WMCore.WMFactory import WMFactory
-import urllib
-import re
 from WMCore.Credential.Proxy import Proxy
+from WMCore.Database.CMSCouch import CouchServer
+
 from AsyncStageOut import getHashLfn
 from AsyncStageOut import getDNFromUserName
-import json
+from AsyncStageOut import getCommonLogFormatter
 
 def getProxy(userdn, group, role, defaultDelegation, logger):
     """
@@ -59,6 +61,9 @@ class ReporterWorker:
         self.dropbox_dir = '%s/dropbox/inputs' % self.config.componentDir
         logging.basicConfig(level=config.log_level)
         self.logger = logging.getLogger('AsyncTransfer-Reporter-%s' % self.user)
+        formatter = getCommonLogFormatter(self.config)
+        for handler in logging.getLogger().handlers:
+            handler.setFormatter(formatter)
         self.uiSetupScript = getattr(self.config, 'UISetupScript', None)
         self.cleanEnvironment = ''
         self.userDN = ''

--- a/src/python/AsyncStageOut/RetryManagerDaemon.py
+++ b/src/python/AsyncStageOut/RetryManagerDaemon.py
@@ -8,17 +8,18 @@ different algorithms.
 """
 __all__ = []
 
+import os
+import time
+import urllib
 import logging
 import datetime
-import time
 import traceback
-import os
-import urllib
 
-from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
-from WMCore.WMFactory         import WMFactory
+from WMCore.WMFactory import WMFactory
 from WMCore.WMException import WMException
 from WMCore.Database.CMSCouch import CouchServer
+
+from AsyncStageOut.BaseDaemon import BaseDaemon
 
 def convertdatetime(t):
     """
@@ -40,7 +41,7 @@ class RetryManagerException(WMException):
     It's totally awesome, except it's not.
     """
 
-class RetryManagerDaemon(BaseWorkerThread):
+class RetryManagerDaemon(BaseDaemon):
     """
     _RetryManagerPoller_
 
@@ -51,15 +52,8 @@ class RetryManagerDaemon(BaseWorkerThread):
         """
         Initialise class members
         """
-        BaseWorkerThread.__init__(self)
-        self.config = config.RetryManager
-        try:
-            self.logger.setLevel(self.config.log_level)
-        except:
-            import logging
-            self.logger = logging.getLogger()
-            self.logger.setLevel(self.config.log_level)
-        self.logger.debug('Configuration loaded')
+        BaseDaemon.__init__(self, config, 'RetryManager')
+
         try:
             server = CouchServer(dburl=self.config.couch_instance, ckey=self.config.opsProxy, cert=self.config.opsProxy)
             self.db = server.connectDatabase(self.config.files_database)

--- a/src/python/AsyncStageOut/StatisticDaemon.py
+++ b/src/python/AsyncStageOut/StatisticDaemon.py
@@ -7,31 +7,22 @@ in runtime database. It creates a document
 per fts server per iteration and removes
 old documents from runtime database.
 """
-from WMCore.Database.CMSCouch import CouchServer
-from WMCore.WorkerThreads.BaseWorkerThread import BaseWorkerThread
-from AsyncStageOut import getFTServer
-
 import datetime
 import traceback
 
-class StatisticDaemon(BaseWorkerThread):
+from WMCore.Database.CMSCouch import CouchServer
+
+from AsyncStageOut import getFTServer
+from AsyncStageOut.BaseDaemon import BaseDaemon
+
+class StatisticDaemon(BaseDaemon):
     """
     _StatisticDeamon_
     Update Async. statistics database on couch
     Delete older finished job from files_database
     """
     def __init__(self, config):
-        BaseWorkerThread.__init__(self)
-        self.config = config.Statistics
-
-        try:
-            self.logger.setLevel(self.config.log_level)
-        except:
-            import logging
-            self.logger = logging.getLogger()
-            self.logger.setLevel(self.config.log_level)
-
-        self.logger.debug('Configuration loaded')
+        BaseDaemon.__init__(self, config, 'Statistics')
 
         server = CouchServer(dburl=self.config.couch_instance, ckey=self.config.opsProxy, cert=self.config.opsProxy)
         self.db = server.connectDatabase(self.config.files_database)

--- a/src/python/AsyncStageOut/__init__.py
+++ b/src/python/AsyncStageOut/__init__.py
@@ -1,6 +1,9 @@
+import os
+import time
+import logging
 import hashlib
 import subprocess
-import os
+
 from WMCore.Services.SiteDB.SiteDB import SiteDBJSON
 from WMCore.Credential.Proxy import Proxy
 
@@ -73,3 +76,17 @@ def getProxy(defaultDelegation, log):
     if timeleft is not None and timeleft > 0:
         return (True, proxyPath)
     return (False, None)
+
+def getCommonLogFormatter(config):
+    """
+    Define a common log messages formatter
+    """
+    logMsgFormat = getattr(config, 'logMsgFormat', "%(asctime)s:%(levelname)s:%(module)s:%(message)s")
+    ## Note: python bug: struct_time objects are not aware of the time zone
+    ## => datefmt="%Y-%m-%d %H:%M:%S %Z(%z)" will always show %Z(%z) = CET(+0000)
+    ## even if the time in the struct_time object corresponds to other time zone.
+    ## Therefore the hardwritting of 'GMT' in the datefmt below. As long as the
+    ## converter attribute of the formatter is time.gmtime, this should be fine.
+    formatter = logging.Formatter(fmt=logMsgFormat, datefmt="%Y-%m-%d %H:%M:%S GMT")
+    formatter.converter = time.gmtime
+    return formatter


### PR DESCRIPTION
Also, are we aware that the WMCore Harness class is trying to read a `logLevel` attribute from the configuration? See https://github.com/dmwm/WMCore/blob/master/src/python/WMCore/Agent/Harness.py#L141-L154 
Since we are not setting it, Harness is using the default `INFO` level, and this way we miss debug messages like for example:
   * https://github.com/dmwm/AsyncStageout/blob/master/src/python/AsyncStageOut/AsyncTransfer.py#L31
   * https://github.com/dmwm/AsyncStageout/blob/master/src/python/AsyncStageOut/AsyncTransfer.py#L63-L64

If we want to have these messages in the log files, either we change `logging.debug` to `logging.info` or we put in the configuration file `config.AsyncTransfer.logLevel = 'DEBUG'`.