### PR TITLE
Reuse connection for fts job which size lower than 100MB

### DIFF
--- a/src/couchapp/AsyncTransfer/views/ftscp_all/map.js
+++ b/src/couchapp/AsyncTransfer/views/ftscp_all/map.js
@@ -1,5 +1,5 @@
 function(doc) {
         if (doc.state == 'new' && doc.lfn) {
-		emit([doc.user, doc.group, doc.role, doc.destination, doc.source], [doc.source_lfn, doc.destination_lfn]);
+		emit([doc.user, doc.group, doc.role, doc.destination, doc.source], [doc.source_lfn, doc.destination_lfn, doc.size, doc.checksums]);
 	}
 }


### PR DESCRIPTION
Use dictionary for preparing rest FTS submission and not appending to string;

First version of reuse connection. If grouped files per link size is lower than 100MB it will say to FTS to reuse connection, otherwise do as it was.
For future, 100MB has to move to config file; Separate small files and big files. If file size is lower than X MB, add to small file queue, which will use reuse connection. Otherwise big file queue which will not reuse connection.
