### PR TITLE
Fix monitor bug in preprod release

### DIFF
--- a/src/Monitor/perl_lib/ASO/Monitor.pm
+++ b/src/Monitor/perl_lib/ASO/Monitor.pm
@@ -651,8 +651,10 @@ sub notify_reporter {
 
 # Now clear the stack of working files that need to be deleted
   foreach ( shift @{$self->{UNLINK}} ) {
-    $self->Logmsg('Unlink ',$_);
-    unlink $_;
+    if ( defined($_) ){
+      $self->Logmsg('Unlink ',$_);
+      unlink $_;
+    }
   }
 
   $self->Logmsg("Notify Reporter of ",$totlen," files for all users") if $totlen;


### PR DESCRIPTION
```
Use of uninitialized value in join or string at /data/srv/asyncstageout/v1.0.4pre1/sw.pre.riahi/slc6_amd64_gcc481/external/p5-log-log4perl/1.26-comp/lib/perl5/Log/Log4perl/Appender.pm line 187.
2016-01-18 09:07:06: ASOMon[214282]: Unlink 
Use of uninitialized value $_ in unlink at /data/srv/asyncstageout/v1.0.4pre1/sw.pre.riahi/slc6_amd64_gcc481/cms/asyncstageout/1.0.4pre1/Monitor/perl_lib/ASO/Monitor.pm line 655
```