### PR TITLE
FTS submission retry value fix

### DIFF
--- a/src/python/AsyncStageOut/TransferWorker.py
+++ b/src/python/AsyncStageOut/TransferWorker.py
@@ -761,18 +761,18 @@ class TransferWorker:
 
                     if force_fail or document['transfer_retry_count'] + 1 > self.max_retry:
                         fileDoc['list_of_transfer_state'] = 'FAILED'
-                        fileDoc['list_of_retry_value'] = 1
+                        fileDoc['list_of_retry_value'] = 0
                     else:
                         fileDoc['list_of_transfer_state'] = 'RETRY'
                     if submission_error:
                         fileDoc['list_of_failure_reason'] = "Job could not be submitted to FTS: temporary problem of FTS"
-                        fileDoc['list_of_retry_value'] = 1
+                        fileDoc['list_of_retry_value'] = 0
                     elif not self.valid_proxy:
                         fileDoc['list_of_failure_reason'] = "Job could not be submitted to FTS: user's proxy expired"
-                        fileDoc['list_of_retry_value'] = 1
+                        fileDoc['list_of_retry_value'] = 0
                     else:
                         fileDoc['list_of_failure_reason'] = "Site config problem."
-                        fileDoc['list_of_retry_value'] = 1
+                        fileDoc['list_of_retry_value'] = 0
 
                     self.logger.debug("update: %s" % fileDoc)
                     updated_lfn.append(docId)


### PR DESCRIPTION
As it is already in the Reporter component the correct value when marking a file as RETRY is 0 not 1. The increasing of the retry count will be done by the RetryManager component. 
In case of value 1, as set if the submission to FTS fails, the retry count will be increased twice, leading to transfer with 3 retries in status RETRY and hence lost by ASO and CRAB.
See: https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/2951.html